### PR TITLE
Add ZipCodeRow cell type

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -237,6 +237,11 @@ class RowsExampleViewController: FormViewController {
                         $0.title = "AccountRow"
                         $0.placeholder = "Placeholder"
                     }
+        
+                <<< ZipCodeRow() {
+                        $0.title = "ZipCodeRow"
+                        $0.placeholder = "90210"
+                    }
     }
     
     func multipleSelectorDone(item:UIBarButtonItem) {

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ This is a list of the rows that are provided by default:
 	+ **DecimalRow**
 	+ **TwitterRow**
 	+ **AccountRow**
+	+ ZipCodeRow
 
 
 * **Date Rows**

--- a/Source/Cells.swift
+++ b/Source/Cells.swift
@@ -404,6 +404,20 @@ public class AccountCell : _FieldCell<String>, CellType {
     }
 }
 
+public class ZipCodeCell : _FieldCell<String>, CellType {
+
+    required public init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+
+    public override func update() {
+        super.update()
+        textField.autocorrectionType = .No
+        textField.autocapitalizationType = .AllCharacters
+        textField.keyboardType = .ASCIICapable
+    }
+}
+
 public class DateCell : Cell<NSDate>, CellType {
     
     lazy public var datePicker : UIDatePicker = {

--- a/Source/Rows.swift
+++ b/Source/Rows.swift
@@ -240,6 +240,12 @@ public class _AccountRow: FieldRow<String, AccountCell> {
     }
 }
 
+public class _ZipCodeRow: FieldRow<String, ZipCodeCell> {
+    public required init(tag: String?) {
+        super.init(tag: tag)
+    }
+}
+
 public class _TimeRow: _DateFieldRow {
     required public init(tag: String?) {
         super.init(tag: tag)
@@ -832,6 +838,19 @@ public final class TwitterRow: _TwitterRow, RowType {
 }
 
 public final class AccountRow: _AccountRow, RowType {
+    required public init(tag: String?) {
+        super.init(tag: tag)
+        onCellHighlight { cell, row  in
+            let color = cell.textLabel?.textColor
+            row.onCellUnHighlight { cell, _ in
+                cell.textLabel?.textColor = color
+            }
+            cell.textLabel?.textColor = cell.tintColor
+        }
+    }
+}
+
+public final class ZipCodeRow: _ZipCodeRow, RowType {
     required public init(tag: String?) {
         super.init(tag: tag)
         onCellHighlight { cell, row  in

--- a/Tests/BaseEurekaTests.swift
+++ b/Tests/BaseEurekaTests.swift
@@ -67,6 +67,7 @@ class BaseEurekaTests: XCTestCase {
             <<< DecimalRow("DecimalRow_f1"){ $0.title = "Decimal" }
             <<< TwitterRow("TwitterRow_f1"){ $0.title = "Twitter" }
             <<< AccountRow("AccountRow_f1"){ $0.title = "Account" }
+            <<< ZipCodeRow("ZipCodeRow_f1"){ $0.title = "Zip Code" }
         
         manySectionsForm =  Section("Section A")
                         +++ Section("Section B")
@@ -91,7 +92,7 @@ class BaseEurekaTests: XCTestCase {
         XCTAssertEqual(dateForm[0].count, 8)
         XCTAssertEqual(shortForm[0].count, 2)
         XCTAssertEqual(fieldForm.count, 1)
-        XCTAssertEqual(fieldForm[0].count, 10)
+        XCTAssertEqual(fieldForm[0].count, 11)
         XCTAssertEqual(manySectionsForm.count, 6)
         XCTAssertEqual(manySectionsForm[0].count, 0)
     }

--- a/Tests/CollectionTests.swift
+++ b/Tests/CollectionTests.swift
@@ -31,16 +31,16 @@ class CollectionTests: BaseEurekaTests {
         // test if the collection function work as expected
         
         fieldForm[0].replaceRange(3...6, with: [CheckRow("check1_ctx")])          // replacing 4 rows with 1
-        XCTAssertEqual(fieldForm[0].count, 7)                                                       // fieldform had 10 rows prior to replacing
+        XCTAssertEqual(fieldForm[0].count, 8)                                                       // fieldform had 10 rows prior to replacing
         fieldForm[0][4] = CheckRow("check2_ctx")                                                    // replacing 5th row
-        XCTAssertEqual(fieldForm[0].count, 7)
+        XCTAssertEqual(fieldForm[0].count, 8)
         
         XCTAssertEqual(fieldForm[0].filter({ $0 is CheckRow }).count, 2)                            // Do I have 2 CheckRows??
 
         fieldForm[0].appendContentsOf([CheckRow("check3_ctx"), CheckRow("check4_ctx"), CheckRow("check5_ctx")])
         // is the same as fieldForm[0] += [...]
         
-        XCTAssertEqual(fieldForm[0].count, 10)
+        XCTAssertEqual(fieldForm[0].count, 11)
     }
     
     func testFormRangeReplaceableCollectionTypeConformance() {

--- a/Tests/HelperMethodTests.swift
+++ b/Tests/HelperMethodTests.swift
@@ -52,13 +52,13 @@ class HelperMethodTests: BaseEurekaTests {
         XCTAssertEqual(row_5_and_6[6], form[0][6])
         
         
-        let row10n = form.nextRowForRow(form[0][9])
+        let row10n = form.nextRowForRow(form[0][8])
         let rownil = form.nextRowForRow(form[2][7])
         
-        XCTAssertEqual(row10n, form[1][0])
+        XCTAssertEqual(row10n, form[0][9])
         XCTAssertNil(rownil)
         
-        let row10p = form.previousRowForRow(form[1][1])
+        let row10p = form.previousRowForRow(form[0][10])
         let rowNilP = form.previousRowForRow(form[0][0])
         
         XCTAssertEqual(row10n, row10p)
@@ -72,9 +72,9 @@ class HelperMethodTests: BaseEurekaTests {
         // Tests the allRows() method
         
         let form = fieldForm + shortForm + dateForm
-        XCTAssertEqual(form.rows.count, 20)
-        XCTAssertEqual(form.rows[11], shortForm[0][1])
-        XCTAssertEqual(form.rows[19], form.rowByTag("IntervalDateRow_d1") as? DateRow)
+        XCTAssertEqual(form.rows.count, 21)
+        XCTAssertEqual(form.rows[12], shortForm[0][1])
+        XCTAssertEqual(form.rows[20], form.rowByTag("IntervalDateRow_d1") as? DateRow)
     }
     
     func testAllRowsWrappedByTagMethod(){
@@ -84,7 +84,7 @@ class HelperMethodTests: BaseEurekaTests {
         
         let rows = form.dictionaryValuesToEvaluatePredicate()
         
-        XCTAssertEqual(rows.count, 20)
+        XCTAssertEqual(rows.count, 21)
     }
     
     func testDisabledRows(){


### PR DESCRIPTION
As created for XLForm in https://github.com/xmartlabs/XLForm/commit/23b93a1a70bb17b8f2f65a4164978b6ac1190d9e this adds the ZipCode row type.

Example also added :+1: 