### PR TITLE
Change oldValue and newValue type to Any?

### DIFF
--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -43,7 +43,7 @@ public protocol FormDelegate : class {
     func rowsHaveBeenAdded(rows: [BaseRow], atIndexPaths:[NSIndexPath])
     func rowsHaveBeenRemoved(rows: [BaseRow], atIndexPaths:[NSIndexPath])
     func rowsHaveBeenReplaced(oldRows oldRows:[BaseRow], newRows: [BaseRow], atIndexPaths: [NSIndexPath])
-    func rowValueHasBeenChanged(row: BaseRow, oldValue: Any, newValue: Any)
+    func rowValueHasBeenChanged(row: BaseRow, oldValue: Any?, newValue: Any?)
 }
 
 //MARK: Header Footer Protocols
@@ -1801,7 +1801,7 @@ public class FormViewController : UIViewController, FormViewControllerProtocol {
     
     //MARK: FormDelegate
     
-    public func rowValueHasBeenChanged(row: BaseRow, oldValue: Any, newValue: Any) {}
+    public func rowValueHasBeenChanged(row: BaseRow, oldValue: Any?, newValue: Any?) {}
     
     //MARK: FormViewControllerProtocol
     

--- a/Tests/BaseEurekaTests.swift
+++ b/Tests/BaseEurekaTests.swift
@@ -111,7 +111,7 @@ public class MyFormDelegate : FormDelegate {
     public var rowsReplacedOut = 0
     public var sectionsReplacedOut = 0
     
-    public func rowValueHasBeenChanged(row: BaseRow, oldValue: Any, newValue: Any) {
+    public func rowValueHasBeenChanged(row: BaseRow, oldValue: Any?, newValue: Any?) {
         valuesChanged++
     }
     


### PR DESCRIPTION
In `FormDelegate.rowValueHasBeenChanged`, `oldValue` and `newValue` are optional and it is easiest to work with optional value to differentiate set/update/delete.