### PR TITLE
Fix constraints update on _FieldCell and SegmentedCell

### DIFF
--- a/Source/Cells.swift
+++ b/Source/Cells.swift
@@ -178,8 +178,8 @@ public class _FieldCell<T where T: Equatable, T: InputTypeInitiable> : Cell<T>, 
     
     public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         if let obj = object, let keyPathValue = keyPath, let changeType = change?[NSKeyValueChangeKindKey] where ((obj === titleLabel && keyPathValue == "text") || (obj === imageView && keyPathValue == "image")) && changeType.unsignedLongValue == NSKeyValueChange.Setting.rawValue {
-            contentView.setNeedsUpdateConstraints()
-            contentView.updateConstraintsIfNeeded()
+            setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
         }
     }
     
@@ -860,7 +860,8 @@ public class SegmentedCell<T: Equatable> : Cell<T>, CellType {
     
     public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         if let obj = object, let changeType = change, let _ = keyPath where obj === titleLabel && keyPath == "text" && changeType[NSKeyValueChangeKindKey]?.unsignedLongValue == NSKeyValueChange.Setting.rawValue{
-            contentView.setNeedsUpdateConstraints()
+            setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
         }
     }
     


### PR DESCRIPTION
Modified observeValueForKeyPath function on _FieldCell and SegmentedCell to correctly update constraints