### PR TITLE
Add missing access control

### DIFF
--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -397,7 +397,7 @@ extension Form {
         }
     }
     
-    func dictionaryValuesToEvaluatePredicate() -> [String: AnyObject] {
+    internal func dictionaryValuesToEvaluatePredicate() -> [String: AnyObject] {
         return rowsByTag.reduce([String: AnyObject]()) {
             var result = $0
             result[$1.0] = $1.1.baseValue as? AnyObject ?? NSNull()


### PR DESCRIPTION
By default, access control level is `internal`, right? I've wondered only in this method, access control isn't defined explicitly. So I've added it.