### PR TITLE
Disable autocorrection and autocapitalization in URLRow()

### DIFF
--- a/Source/Cells.swift
+++ b/Source/Cells.swift
@@ -399,6 +399,8 @@ public class URLCell : _FieldCell<NSURL>, CellType {
     
     public override func setup() {
         super.setup()
+        textField.autocorrectionType = .No
+        textField.autocapitalizationType = .None
         textField.keyboardType = .URL
     }
 }


### PR DESCRIPTION
I think it would be necessary to disable autocorrection and autocapitalisation in URLRow() by default.