### PR TITLE
TextViewCell Placeholder/TextView Layout

### DIFF
--- a/Source/Cells.swift
+++ b/Source/Cells.swift
@@ -681,16 +681,16 @@ public class _TextAreaCell<T where T: Equatable, T: InputTypeInitiable> : Cell<T
         textView.keyboardType = .Default
         textView.delegate = self
         textView.font = .preferredFontForTextStyle(UIFontTextStyleBody)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = UIEdgeInsetsZero
         placeholderLabel.font = textView.font
         selectionStyle = .None
         contentView.addSubview(textView)
         contentView.addSubview(placeholderLabel)
         
         let views : [String: AnyObject] =  ["textView": textView, "label": placeholderLabel]
-        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-8-[label]", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
-        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-0-[textView]-0-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
-        contentView.addConstraint(NSLayoutConstraint(item: textView, attribute: .Top, relatedBy: .Equal, toItem: contentView, attribute: .Top, multiplier: 1, constant: 0))
-        contentView.addConstraint(NSLayoutConstraint(item: textView, attribute: .Bottom, relatedBy: .Equal, toItem: contentView, attribute: .Bottom, multiplier: 1, constant: 0))
+        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[label]", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
+        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[textView]-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[textView]-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[label]-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
     }


### PR DESCRIPTION
Fixed bug where the TextViewCell's placeholderLabel did not line up with the textView's content.

To see an example of the issue, run the Example project and open the Native iOS Event Form. The last row entitled Notes has a placeholder, but when you start typing, the content does not line up with the placeholder's position.

A good writeup of the underlying problem and solution can be found here: http://stackoverflow.com/a/18987810/2712112

Before:
![screen shot 2016-01-11 at 9 13 34 am](https://cloud.githubusercontent.com/assets/4681530/12236151/27d33c10-b846-11e5-9c81-a891e1ef58c2.png)

After:
![screen shot 2016-01-11 at 9 13 56 am](https://cloud.githubusercontent.com/assets/4681530/12236156/2cf3ce8a-b846-11e5-8a26-2d4dc4efcc98.png)

