### PR TITLE
Made arrayData public let

### DIFF
--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -2117,7 +2117,7 @@ public enum ControllerProvider<VCType: UIViewController>{
  */
 public struct DataProvider<T: Equatable> {
     
-    var arrayData: [T]?
+    public let arrayData: [T]?
     
     public init(arrayData: [T]){
         self.arrayData = arrayData


### PR DESCRIPTION
Changed arrayData property to be a public let.

Backstory: I'm using Eureka in a project where I want to create my own custom selector controller. And when doing that it helps if I can access the arrayData property, as you do with SelectorViewController/MultipleSelectorViewController/SelectorAlertController/etc.