### PR TITLE
Fix image row source types

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		048D0DA61C46A7F700399A22 /* ImageRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048D0DA51C46A7F700399A22 /* ImageRowTests.swift */; };
 		284729601BBA4C5E006F41DA /* FormValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847295F1BBA4C5E006F41DA /* FormValuesTests.swift */; };
 		2887898B1BCC160F00B5FDF0 /* CallbacksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2887898A1BCC160F00B5FDF0 /* CallbacksTests.swift */; };
 		28B12FD51BA0E83C00F27A23 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 28B12FD41BA0E83C00F27A23 /* Assets.xcassets */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		048D0DA51C46A7F700399A22 /* ImageRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRowTests.swift; sourceTree = "<group>"; };
 		2847295F1BBA4C5E006F41DA /* FormValuesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FormValuesTests.swift; path = Tests/FormValuesTests.swift; sourceTree = SOURCE_ROOT; };
 		2887898A1BCC160F00B5FDF0 /* CallbacksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CallbacksTests.swift; path = Tests/CallbacksTests.swift; sourceTree = SOURCE_ROOT; };
 		28B12FD41BA0E83C00F27A23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Source/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -134,6 +136,7 @@
 				28B9B6911BC3191000CCA9B4 /* SetValuesTests.swift */,
 				2887898A1BCC160F00B5FDF0 /* CallbacksTests.swift */,
 				BFF9C6C41C170BB000928216 /* SelectableSectionTests.swift */,
+				048D0DA51C46A7F700399A22 /* ImageRowTests.swift */,
 			);
 			name = Tests;
 			path = EurekaTests;
@@ -271,6 +274,7 @@
 				284729601BBA4C5E006F41DA /* FormValuesTests.swift in Sources */,
 				28B9B6901BC306F100CCA9B4 /* RowByTagTests.swift in Sources */,
 				2887898B1BCC160F00B5FDF0 /* CallbacksTests.swift in Sources */,
+				048D0DA61C46A7F700399A22 /* ImageRowTests.swift in Sources */,
 				BFF9C6C61C170BB900928216 /* SelectableSectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EurekaTests/ImageRowTests.swift
+++ b/EurekaTests/ImageRowTests.swift
@@ -1,0 +1,102 @@
+//
+//  ImageRowTests.swift
+//  Eureka
+//
+//  Created by Florian Fittschen on 13/01/16.
+//  Copyright © 2016 Xmartlabs. All rights reserved.
+//
+
+import XCTest
+
+@testable import Eureka
+
+class ImageRowTests: XCTestCase {
+    
+    var formVC = FormViewController()
+    
+    var availableSources: ImageRowSourceTypes {
+        var result: ImageRowSourceTypes = []
+        
+        if UIImagePickerController.isSourceTypeAvailable(.PhotoLibrary) {
+            result.insert(ImageRowSourceTypes.PhotoLibrary)
+        }
+        if UIImagePickerController.isSourceTypeAvailable(.Camera) {
+            result.insert(ImageRowSourceTypes.Camera)
+        }
+        if UIImagePickerController.isSourceTypeAvailable(.SavedPhotosAlbum) {
+            result.insert(ImageRowSourceTypes.SavedPhotosAlbum)
+        }
+        return result
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        let form = Form()
+        
+        form +++ Section()
+            <<< ImageRow("DefaultImageRow") {
+                $0.title = $0.tag
+                // Default sourceTypes == .All
+            }
+            <<< ImageRow("SingleSourceImageRow") { (row: ImageRow) in
+                row.title = row.tag
+                row.sourceTypes = .Camera
+            }
+            <<< ImageRow("TwoSourcesImageRow") { (row: ImageRow) in
+                row.title = row.tag
+                row.sourceTypes = [.SavedPhotosAlbum, .PhotoLibrary]
+            }
+        formVC.form = form
+        
+        // load the view to test the cells
+        formVC.view.frame = CGRect(x: 0, y: 0, width: 375, height: 3000)
+        formVC.tableView?.frame = formVC.view.frame
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testEmptyImageRowSourceTypes() {
+        let result = ImageRowSourceTypes()
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertFalse(result.contains(.PhotoLibrary))
+        XCTAssertFalse(result.contains(.Camera))
+        XCTAssertFalse(result.contains(.SavedPhotosAlbum))
+    }
+    
+    func testImagePickerControllerSourceTypeRawValue() {
+        XCTAssert(UIImagePickerControllerSourceType.PhotoLibrary.rawValue == ImageRowSourceTypes.PhotoLibrary.imagePickerControllerSourceTypeRawValue)
+        XCTAssert(UIImagePickerControllerSourceType.Camera.rawValue == ImageRowSourceTypes.Camera.imagePickerControllerSourceTypeRawValue)
+        XCTAssert(UIImagePickerControllerSourceType.SavedPhotosAlbum.rawValue == ImageRowSourceTypes.SavedPhotosAlbum.imagePickerControllerSourceTypeRawValue)
+    }
+    
+    func testImageRow() {
+        guard let defaultImageRow = formVC.form.rowByTag("DefaultImageRow") as? ImageRow else {
+            XCTFail()
+            return
+        }
+        
+        guard let singleSourceImageRow = formVC.form.rowByTag("SingleSourceImageRow") as? ImageRow else {
+            XCTFail()
+            return
+        }
+        
+        guard let twoSourcesImageRow = formVC.form.rowByTag("TwoSourcesImageRow") as? ImageRow else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssert(defaultImageRow.sourceTypes == ImageRowSourceTypes.All)
+        XCTAssert(singleSourceImageRow.sourceTypes == ImageRowSourceTypes.Camera)
+        XCTAssert(twoSourcesImageRow.sourceTypes == ImageRowSourceTypes([ImageRowSourceTypes.SavedPhotosAlbum, ImageRowSourceTypes.PhotoLibrary]))
+        
+        let sourceTypes = defaultImageRow.sourceTypes.intersect(availableSources)
+        formVC.tableView(formVC.tableView!, didSelectRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0))
+        XCTAssert(defaultImageRow.sourceTypes == sourceTypes)
+    }
+    
+    
+    
+}


### PR DESCRIPTION
Hi, I really appreciate the refactored `ImageRow` and the use of `ActionSheets`!

Looking at the source, I thought I can create an `ImageRow` like this:
```
<<< ImageRow(){
    $0.title = "ImageRow"
    $0.sourceTypes = [ImageRowSourceTypes.Camera, ImageRowSourceTypes.PhotoLibrary]
}
```
But this doesn't work. Xcode says "Type 'ImageRowSourceTypes' has no member 'Camera'".
I tried to change the options in `ImageRowSourceTypes` to public, but then the app crashes on the simulator with the message "Source type 1 not available".

This error appeared, because if an `OptionSetType` gets initialized with `0` it automatically referes to empty / `.None` (which is the case for `UIImagePickerControllerSourceType.PhotoLibrary`). This produced some weird behaviour, causing the crash described above. 

I changed the code to make the following code possible, fix those issues which caused the crash after making the options public and wrote a few basic tests.

```
<<< ImageRow(){
    $0.title = "ImageRow"
    $0.sourceTypes = .PhotoLibrary
}
<<< ImageRow(){
    $0.title = "ImageRow"
    $0.sourceTypes = [ImageRowSourceTypes.Camera, ImageRowSourceTypes.PhotoLibrary]
}
```

Just let me know if there is any feedback ;)
