### PR TITLE
Fix a bug that removes existing observers when other type of observer is added

### DIFF
--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -591,13 +591,15 @@ extension Form {
     
     private func addRowObservers(taggable: Taggable, rowTags: [String], type: ConditionType) {
         for rowTag in rowTags{
+            if rowObservers[rowTag] == nil {
+              rowObservers[rowTag] = Dictionary()
+            }
             if let _ = rowObservers[rowTag]?[type]{
                 if !rowObservers[rowTag]![type]!.contains({ $0 === taggable }){
                     rowObservers[rowTag]?[type]!.append(taggable)
                 }
             }
             else{
-                rowObservers[rowTag] = Dictionary()
                 rowObservers[rowTag]?[type] = [taggable]
             }
         }


### PR DESCRIPTION
### Bug Reproduction
1. Add .Hidden observer
2. Add .Disabled observer
3. Then .Hidden observer is removed.

### Bug Demo
Find out working bug reproduction demo.
https://github.com/jechol/eureka-mixed-hidden-disabled-observer-bug-reproduce
