### PR TITLE
Add teardown() to Cell to clean up delegates and targets.

### DIFF
--- a/Source/Cells.swift
+++ b/Source/Cells.swift
@@ -136,6 +136,12 @@ public class _FieldCell<T where T: Equatable, T: InputTypeInitiable> : Cell<T>, 
         
     }
     
+    public override func teardown() {
+        super.teardown()
+        textField.delegate=nil
+        textField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+    }
+    
     public override func update() {
         super.update()
         detailTextLabel?.text = nil
@@ -462,6 +468,10 @@ public class DateCell : Cell<NSDate>, CellType {
         datePicker.addTarget(self, action: Selector("datePickerValueChanged:"), forControlEvents: .ValueChanged)
     }
     
+    public override func teardown() {
+        super.teardown()
+        datePicker.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+    }
     
     public override func update() {
         super.update()
@@ -565,6 +575,11 @@ public class DatePickerCell : Cell<NSDate>, CellType {
         datePicker.datePickerMode = datePickerMode()
     }
     
+    public override func teardown() {
+        super.teardown()
+        datePicker.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+    }
+    
     public override func update() {
         super.update()
         selectionStyle = row.isDisabled ? .None : .Default
@@ -623,6 +638,12 @@ public class PickerCell<T where T: Equatable> : Cell<T>, CellType, UIPickerViewD
         editingAccessoryType = .None
         picker.delegate = self
         picker.dataSource = self
+    }
+    
+    public override func teardown() {
+        super.teardown()
+        picker.delegate = nil
+        picker.dataSource = nil
     }
     
     public override func update(){
@@ -693,6 +714,11 @@ public class _TextAreaCell<T where T: Equatable, T: InputTypeInitiable> : Cell<T
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[textView]-|", options: [], metrics: nil, views: views))
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[textView]-|", options: [], metrics: nil, views: views))
         contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[label]-|", options: [], metrics: nil, views: views))
+    }
+    
+    public override func teardown() {
+        super.teardown()
+        textView.delegate=nil
     }
     
     public override func update() {
@@ -881,6 +907,11 @@ public class SwitchCell : Cell<Bool>, CellType {
         switchControl?.addTarget(self, action: "valueChanged", forControlEvents: .ValueChanged)
     }
     
+    public override func teardown() {
+        super.teardown()
+        switchControl?.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+    }
+    
     public override func update() {
         super.update()
         switchControl?.on = row.value ?? false
@@ -926,6 +957,11 @@ public class SegmentedCell<T: Equatable> : Cell<T>, CellType {
         imageView?.addObserver(self, forKeyPath: "image", options: [.Old, .New], context: nil)
         segmentedControl.addTarget(self, action: "valueChanged", forControlEvents: .ValueChanged)
         contentView.addConstraint(NSLayoutConstraint(item: segmentedControl, attribute: .CenterY, relatedBy: .Equal, toItem: contentView, attribute: .CenterY, multiplier: 1, constant: 0))
+    }
+    
+    public override func teardown() {
+        super.teardown()
+        segmentedControl.removeTarget(self, action: nil, forControlEvents: .AllEvents)
     }
     
     public override func update() {
@@ -1144,6 +1180,20 @@ public class DefaultPostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, 
 		cityTextField.addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
 		countryTextField.addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
 	}
+    
+    public override func teardown() {
+        super.teardown()
+        streetTextField.delegate=nil
+        streetTextField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+        stateTextField.delegate=nil
+        stateTextField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+        postalCodeTextField.delegate=nil
+        postalCodeTextField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+        cityTextField.delegate=nil
+        cityTextField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+        countryTextField.delegate=nil
+        countryTextField.removeTarget(self, action: nil, forControlEvents: .AllEvents)
+    }
 	
 	public override func update() {
 		super.update()

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -1601,7 +1601,9 @@ public class Row<T: Equatable, Cell: CellType where Cell: BaseCell, Cell.Value =
     
     /// Allow cell to cleanup (opposite of setup)
     deinit{
-        cell.teardown()
+        if let cell = _cell {
+            cell.teardown()
+        }
     }
     
     /**

--- a/Source/Core.swift
+++ b/Source/Core.swift
@@ -297,6 +297,11 @@ public protocol BaseCellType : class {
     func setup()
     
     /**
+     Method called once when destroying a cell. Responsible for cleaning up.
+     */
+    func teardown()
+    
+    /**
      Method called each time the cell is updated (e.g. 'cellForRowAtIndexPath' is called). Responsible for updating the cell.
      */
     func update()
@@ -1594,6 +1599,11 @@ public class Row<T: Equatable, Cell: CellType where Cell: BaseCell, Cell.Value =
         super.init(tag: tag)
     }
     
+    /// Allow cell to cleanup (opposite of setup)
+    deinit{
+        cell.teardown()
+    }
+    
     /**
      Method that reloads the cell
      */
@@ -1959,6 +1969,7 @@ public class BaseCell : UITableViewCell, BaseCellType {
     }
     
     public func setup(){}
+    public func teardown(){}
     public func update() {}
     
     public func didSelect() {}
@@ -2018,6 +2029,13 @@ public class Cell<T: Equatable> : BaseCell, TypedCellType {
      */
     public override func setup(){
         super.setup()
+    }
+    
+    /**
+     Function responsible for tearing down the cell at destruction time of the Row
+     */
+    public override func teardown(){
+        super.teardown()
     }
     
     /**


### PR DESCRIPTION
The PickerInlineRow always crashes when you close it while it is still spinning.
CountDownInlineRow also, but less often.

Added a teardown() function on the Cell to remove delegates from pickers and cleanup addTarget(self) references.

teardown() is called when the Row is deinitialised, it is the opposite of setup()
