### PR TITLE
Update rows statuses of "hidden" and "disabled" after adding all rows

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -147,6 +147,9 @@ extension BaseRow {
             self.section?.form?.rowsByTag[t] = self
             self.section?.form?.tagToValues[t] = baseValue as? AnyObject ?? NSNull()
         }
+    }
+    
+    final func updateRowInSection() {
         addToRowObservers()
         evaluateHidden()
         evaluateDisabled()

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -203,6 +203,7 @@ extension Section : RangeReplaceableCollectionType {
         kvoWrapper.rows.insertObject(formRow, atIndex: kvoWrapper.rows.count)
         kvoWrapper._allRows.append(formRow)
         formRow.wasAddedToFormInSection(self)
+        formRow.updateRowInSection()
     }
     
     public func appendContentsOf<S : SequenceType where S.Generator.Element == BaseRow>(newElements: S) {
@@ -210,6 +211,10 @@ extension Section : RangeReplaceableCollectionType {
         kvoWrapper._allRows.appendContentsOf(newElements)
         for row in newElements{
             row.wasAddedToFormInSection(self)
+        }
+        
+        for row in newElements {
+            row.updateRowInSection()
         }
     }
     
@@ -227,6 +232,10 @@ extension Section : RangeReplaceableCollectionType {
         kvoWrapper._allRows.insertContentsOf(newElements, at: indexForInsertionAtIndex(subRange.startIndex))
         for row in newElements{
             row.wasAddedToFormInSection(self)
+        }
+        
+        for row in newElements {
+            row.updateRowInSection()
         }
     }
     
@@ -283,6 +292,10 @@ extension Section /* Condition */{
         evaluateHidden()
         for row in kvoWrapper._allRows {
             row.wasAddedToFormInSection(self)
+        }
+        
+        for row in kvoWrapper._allRows {
+            row.updateRowInSection()
         }
     }
     


### PR DESCRIPTION
If you have some complex dependency between rows (for example in row A visibility is depended on the value of row B which is located below row A) then you need to have an access to this row (which may not exists in the UI at that moment). Thus, the "visibility" or "disable" status of row A is not right.

In my change I split the logic of row adding and updating phases. Thus, in the first step we add all rows to the section and only after that evaluate "hidden" and "disable" rules for each added row.