### PR TITLE
Fix lack of sort on display value for GenericMultipleSelectorRow

### DIFF
--- a/Source/Rows/Common/GenericMultipleSelectorRow.swift
+++ b/Source/Rows/Common/GenericMultipleSelectorRow.swift
@@ -33,7 +33,7 @@ public class GenericMultipleSelectorRow<T: Hashable, Cell: CellType, VCType: Typ
     required public init(tag: String?) {
         super.init(tag: tag)
         displayValueFor = { (rowValue: Set<T>?) in
-            return rowValue?.map({ String($0) }).joinWithSeparator(", ")
+            return rowValue?.map({ String($0) }).sort().joinWithSeparator(", ")
         }
         presentationMode = .Show(controllerProvider: ControllerProvider.Callback { return VCType() }, completionCallback: { vc in vc.navigationController?.popViewControllerAnimated(true) })
     }


### PR DESCRIPTION
Just added a sort() on the display values so now there is a pattern on the results, as it uses Set, before this change the values shown were not sorted in any way. 

More details can be found on: http://stackoverflow.com/questions/37597870/