### PR TITLE
Reduce content hugging priority of UISegmentedControl inside SegmentedRow

### DIFF
--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -20,7 +20,7 @@ public class SegmentedCell<T: Equatable> : Cell<T>, CellType {
     lazy public var segmentedControl : UISegmentedControl = {
         let result = UISegmentedControl()
         result.translatesAutoresizingMaskIntoConstraints = false
-        result.setContentHuggingPriority(500, forAxis: .Horizontal)
+        result.setContentHuggingPriority(250, forAxis: .Horizontal)
         return result
     }()
     private var dynamicConstraints = [NSLayoutConstraint]()


### PR DESCRIPTION
This solves a constraint resolution issue that can appear when reloading cells. Having the hugging priority of the label and the segmented control both equal 500 makes the layout engine choose different views at different times (initial load vs. cell reload for example). 

Reducing the hugging priority of the segmented control allows it to fill the remaining space more egearly than it's peers.

My rationale for reducing the content hugging priority of the segmented control is the default appearance of the demo (and my own forms) initially appear after load with the segmented control taking over the spare space beyond it's initial width constraint (see screenshot). 

![screen shot 2016-06-28 at 7 04 32 pm](https://cloud.githubusercontent.com/assets/17407/16410150/7a7d1366-3d64-11e6-8c28-4257001a2302.png)

closes xmartlabs/Eureka#478