### PR TITLE
Rename hightlightCell to highlightCell. (Remove extra 't'.)

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -94,7 +94,7 @@ public class BaseRow : BaseRowType {
     /**
      Method that is responsible for highlighting the cell.
      */
-    public func hightlightCell() {}
+    public func highlightCell() {}
     
     /**
      Method that is responsible for unhighlighting the cell.

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -553,7 +553,7 @@ public class FormViewController : UIViewController, FormViewControllerProtocol {
     Called when a cell becomes first responder
     */
     public final func beginEditing<T:Equatable>(cell: Cell<T>) {
-        cell.row.hightlightCell()
+        cell.row.highlightCell()
         guard let _ = tableView where (form.inlineRowHideOptions ?? Form.defaultInlineRowHideOptions).contains(.FirstResponderChanges) else { return }
         let row = cell.baseRow
         let inlineRow = row._inlineRow

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -133,8 +133,8 @@ public class Row<T: Equatable, Cell: CellType where Cell: TypedCellType, Cell: B
     /**
      Method that is responsible for highlighting the cell.
      */
-    override public func hightlightCell() {
-        super.hightlightCell()
+    override public func highlightCell() {
+        super.highlightCell()
         cell.highlight()
         RowDefaults.onCellHighlight["\(self.dynamicType)"]?(cell, self)
         callbackOnCellHighlight?()


### PR DESCRIPTION
Fixed a typo. Potentially breaks backwards compatibility for 1.6.x users (compiler error), so might want to defer merging til a 2.x release.