### PR TITLE
Converts to Swift 3 Syntax (2 Test Failures)

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -585,16 +585,16 @@ class NativeEventFormViewController : FormViewController {
                     let endDate: DateTimeInlineRow! = self?.form.rowByTag("Ends")
                     
                     if row.value ?? false {
-                        startDate.dateFormatter?.dateStyle = .medium
-                        startDate.dateFormatter?.timeStyle = .none
-                        endDate.dateFormatter?.dateStyle = .medium
-                        endDate.dateFormatter?.timeStyle = .none
+                        startDate.dateFormatter?.dateStyle = .mediumStyle
+                        startDate.dateFormatter?.timeStyle = .noStyle
+                        endDate.dateFormatter?.dateStyle = .mediumStyle
+                        endDate.dateFormatter?.timeStyle = .noStyle
                     }
                     else {
-                        startDate.dateFormatter?.dateStyle = .short
-                        startDate.dateFormatter?.timeStyle = .short
-                        endDate.dateFormatter?.dateStyle = .short
-                        endDate.dateFormatter?.timeStyle = .short
+                        startDate.dateFormatter?.dateStyle = .shortStyle
+                        startDate.dateFormatter?.timeStyle = .shortStyle
+                        endDate.dateFormatter?.dateStyle = .shortStyle
+                        endDate.dateFormatter?.timeStyle = .shortStyle
                     }
                     startDate.updateCell()
                     endDate.updateCell()
@@ -898,7 +898,7 @@ class FormatterExample : FormViewController {
                 $0.title = "Currency style"
                 $0.value = 2015
                 let formatter = CurrencyFormatter()
-                formatter.locale = .current
+                formatter.locale = .current()
                 formatter.numberStyle = .currency
                 $0.formatter = formatter
             }
@@ -906,7 +906,7 @@ class FormatterExample : FormViewController {
                 $0.title = "Scientific style"
                 $0.value = 2015
                 let formatter = NumberFormatter()
-                formatter.locale = .current
+                formatter.locale = .current()
                 formatter.numberStyle = .scientific
                 $0.formatter = formatter
             }
@@ -914,7 +914,7 @@ class FormatterExample : FormViewController {
                 $0.title = "Spell out style"
                 $0.value = 2015
                 let formatter = NumberFormatter()
-                formatter.locale = .current
+                formatter.locale = .current()
                 formatter.numberStyle = .spellOut
                 $0.formatter = formatter
             }
@@ -923,16 +923,16 @@ class FormatterExample : FormViewController {
                 $0.title = "Short style"
                 $0.value = Date()
                 let formatter = DateFormatter()
-                formatter.locale = .current
-                formatter.dateStyle = .short
+                formatter.locale = .current()
+                formatter.dateStyle = .shortStyle
                 $0.dateFormatter = formatter
             }
             <<< DateRow(){
                 $0.title = "Long style"
                 $0.value = Date()
                 let formatter = DateFormatter()
-                formatter.locale = .current
-                formatter.dateStyle = .long
+                formatter.locale = .current()
+                formatter.dateStyle = .longStyle
                 $0.dateFormatter = formatter
             }
         +++ Section("Other formatters")
@@ -1021,8 +1021,8 @@ class InlineRowsController: FormViewController {
                     var dateComp = DateComponents()
                     dateComp.hour = 18
                     dateComp.minute = 33
-                    (dateComp as NSDateComponents).timeZone = TimeZone.system
-                    $0.value = Calendar.current.date(from: dateComp)
+                    (dateComp as NSDateComponents).timeZone = TimeZone.system()
+                    $0.value = Calendar.current().date(from: dateComp)
                 }
         
         +++ Section("Generic inline picker")
@@ -1030,7 +1030,7 @@ class InlineRowsController: FormViewController {
             <<< PickerInlineRow<Date>("PickerInlineRow") { (row : PickerInlineRow<Date>) -> Void in
                     row.title = row.tag
                     row.displayValueFor = { (rowValue: Date?) in
-                        return rowValue.map { "Year \(Calendar.current.component(.year, from: $0))" }
+                        return rowValue.map { "Year \(Calendar.current().component(.year, from: $0))" }
                     }
                     row.options = []
                     var date = Date()

--- a/Example/UITests/FieldRowUITests.swift
+++ b/Example/UITests/FieldRowUITests.swift
@@ -133,7 +133,7 @@ class FieldRowUITests: XCTestCase {
 
     lazy var decimalFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
-        numberFormatter.locale = .currentLocale()
+        numberFormatter.locale = .current()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 2
         return numberFormatter
@@ -141,7 +141,7 @@ class FieldRowUITests: XCTestCase {
     
     lazy var intFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
-        numberFormatter.locale = .currentLocale()
+        numberFormatter.locale = .current()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 0
         numberFormatter.maximumFractionDigits = 0

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -509,14 +509,14 @@ public class FormViewController : UIViewController, FormViewControllerProtocol {
             }
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(FormViewController.keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(FormViewController.keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        NotificationCenter.default().addObserver(self, selector: #selector(FormViewController.keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default().addObserver(self, selector: #selector(FormViewController.keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        NotificationCenter.default().removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default().removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
     public override func prepare(for segue: UIStoryboardSegue, sender: AnyObject?) {

--- a/Source/Rows/Common/DateInlineFieldRow.swift
+++ b/Source/Rows/Common/DateInlineFieldRow.swift
@@ -56,7 +56,7 @@ public class _DateInlineFieldRow: Row<DateInlineCell>, DatePickerRowProtocol, No
     required public init(tag: String?) {
         super.init(tag: tag)
         dateFormatter = DateFormatter()
-        dateFormatter?.locale = Locale.current
+        dateFormatter?.locale = Locale.current()
         displayValueFor = { [unowned self] value in
             guard let val = value, let formatter = self.dateFormatter else { return nil }
             return formatter.string(from: val)

--- a/Source/Rows/Common/DecimalFormatter.swift
+++ b/Source/Rows/Common/DecimalFormatter.swift
@@ -12,7 +12,7 @@ public class DecimalFormatter : NumberFormatter, FormatterProtocol {
     
     public override init() {
         super.init()
-        locale = Locale.current
+        locale = Locale.current()
         numberStyle = .decimal
         minimumFractionDigits = 2
         maximumFractionDigits = 2

--- a/Source/Rows/DateInlineRow.swift
+++ b/Source/Rows/DateInlineRow.swift
@@ -26,8 +26,8 @@ public class _DateInlineRow: _DateInlineFieldRow {
     
     public required init(tag: String?) {
         super.init(tag: tag)
-        dateFormatter?.timeStyle = .none
-        dateFormatter?.dateStyle = .medium
+        dateFormatter?.timeStyle = .noStyle
+        dateFormatter?.dateStyle = .mediumStyle
     }
     
     public func setupInlineRow(_ inlineRow: DatePickerRow) {
@@ -41,8 +41,8 @@ public class _TimeInlineRow: _DateInlineFieldRow {
     
     public required init(tag: String?) {
         super.init(tag: tag)
-        dateFormatter?.timeStyle = .short
-        dateFormatter?.dateStyle = .none
+        dateFormatter?.timeStyle = .shortStyle
+        dateFormatter?.dateStyle = .noStyle
     }
     
     public func setupInlineRow(_ inlineRow: TimePickerRow) {
@@ -56,8 +56,8 @@ public class _DateTimeInlineRow: _DateInlineFieldRow {
     
     public required init(tag: String?) {
         super.init(tag: tag)
-        dateFormatter?.timeStyle = .short
-        dateFormatter?.dateStyle = .short
+        dateFormatter?.timeStyle = .shortStyle
+        dateFormatter?.dateStyle = .shortStyle
     }
     
     public func setupInlineRow(_ inlineRow: DateTimePickerRow) {
@@ -75,8 +75,8 @@ public class _CountDownInlineRow: _DateInlineFieldRow {
             guard let date = $0 else {
                 return nil
             }
-            let hour = Calendar.current.component(.hour, from: date as Date)
-            let min = Calendar.current.component(.minute, from: date as Date)
+            let hour = Calendar.current().component(.hour, from: date as Date)
+            let min = Calendar.current().component(.minute, from: date as Date)
             if hour == 1{
                 return "\(hour) hour \(min) min"
             }

--- a/Source/Rows/DateRow.swift
+++ b/Source/Rows/DateRow.swift
@@ -12,9 +12,9 @@ public class _DateRow: _DateFieldRow {
     required public init(tag: String?) {
         super.init(tag: tag)
         dateFormatter = DateFormatter()
-        dateFormatter?.timeStyle = .none
-        dateFormatter?.dateStyle = .medium
-        dateFormatter?.locale = Locale.current
+        dateFormatter?.timeStyle = .noStyle
+        dateFormatter?.dateStyle = .mediumStyle
+        dateFormatter?.locale = Locale.current()
     }
 }
 
@@ -23,9 +23,9 @@ public class _TimeRow: _DateFieldRow {
     required public init(tag: String?) {
         super.init(tag: tag)
         dateFormatter = DateFormatter()
-        dateFormatter?.timeStyle = .short
-        dateFormatter?.dateStyle = .none
-        dateFormatter?.locale = Locale.current
+        dateFormatter?.timeStyle = .shortStyle
+        dateFormatter?.dateStyle = .noStyle
+        dateFormatter?.locale = Locale.current()
     }
 }
 
@@ -33,9 +33,9 @@ public class _DateTimeRow: _DateFieldRow {
     required public init(tag: String?) {
         super.init(tag: tag)
         dateFormatter = DateFormatter()
-        dateFormatter?.timeStyle = .short
-        dateFormatter?.dateStyle = .short
-        dateFormatter?.locale = Locale.current
+        dateFormatter?.timeStyle = .shortStyle
+        dateFormatter?.dateStyle = .shortStyle
+        dateFormatter?.locale = Locale.current()
     }
 }
 
@@ -49,7 +49,7 @@ public class _CountDownRow: _DateFieldRow {
             if let formatter = self.dateFormatter {
                 return formatter.string(from: val)
             }
-            let components = Calendar.current.components(Calendar.Unit.minute.union(Calendar.Unit.hour), from: val as Date)
+            let components = Calendar.current().components(Calendar.Unit.minute.union(Calendar.Unit.hour), from: val as Date)
             var hourString = "hour"
             if components.hour != 1{
                 hourString += "s"

--- a/Source/Rows/FieldsRow.swift
+++ b/Source/Rows/FieldsRow.swift
@@ -215,7 +215,7 @@ public class _IntRow: FieldRow<IntCell> {
     public required init(tag: String?) {
         super.init(tag: tag)
         let numberFormatter = NumberFormatter()
-        numberFormatter.locale = Locale.current
+        numberFormatter.locale = Locale.current()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 0
         formatter = numberFormatter
@@ -251,7 +251,7 @@ public class _DecimalRow: FieldRow<DecimalCell> {
     public required init(tag: String?) {
         super.init(tag: tag)
         let numberFormatter = NumberFormatter()
-        numberFormatter.locale = Locale.current
+        numberFormatter.locale = Locale.current()
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 2
         formatter = numberFormatter

--- a/Tests/BaseEurekaTests.swift
+++ b/Tests/BaseEurekaTests.swift
@@ -138,15 +138,15 @@ public class MyFormDelegate : FormDelegate {
         sectionsReplacedOut += oldSections.count
     }
     
-    public func rowsHaveBeenAdded(rows: [BaseRow], atIndexPaths:[NSIndexPath]){
+    public func rowsHaveBeenAdded(_ rows: [BaseRow], atIndexPaths:[IndexPath]){
         rowsAdded += rows.count
     }
     
-    public func rowsHaveBeenRemoved(rows: [BaseRow], atIndexPaths:[NSIndexPath]){
+    public func rowsHaveBeenRemoved(_ rows: [BaseRow], atIndexPaths:[IndexPath]){
         rowsRemoved += rows.count
     }
     
-    public func rowsHaveBeenReplaced(oldRows:[BaseRow], newRows: [BaseRow], atIndexPaths: [NSIndexPath]){
+    public func rowsHaveBeenReplaced(oldRows:[BaseRow], newRows: [BaseRow], atIndexPaths: [IndexPath]){
         rowsReplacedIn += newRows.count
         rowsReplacedOut += oldRows.count
     }

--- a/Tests/BaseEurekaTests.swift
+++ b/Tests/BaseEurekaTests.swift
@@ -49,9 +49,9 @@ class BaseEurekaTests: XCTestCase {
             <<< DateTimeRow("DateTimeRow_d1"){ $0.title = "DateTime"; $0.value = Date() }
             <<< TimeRow("TimeRow_d1"){ $0.title = "Time"; $0.value = Date() }
             <<< CountDownRow("CountDownRow_d1"){ $0.title = "CountDown"; $0.value = Date() }
-            <<< DateRow("MinDateRow_d1"){ $0.title = "Date(min)"; $0.value = Date(); $0.minimumDate = $0.value?.addTimeInterval(-60*60*24) }
-            <<< DateRow("MaxDateRow_d1"){ $0.title = "Date(max)"; $0.value = Date(); $0.maximumDate = $0.value?.addTimeInterval(60*60*24) }
-            <<< DateRow("MinMaxDateRow_d1"){ $0.title = "Date(min/max)"; $0.value = Date(); $0.minimumDate = $0.value?.addTimeInterval(-60*60*24); $0.maximumDate = $0.value?.addTimeInterval(60*60*24)  }
+            <<< DateRow("MinDateRow_d1"){ $0.title = "Date(min)"; $0.value = Date(); $0.minimumDate = $0.value?.addingTimeInterval(-60*60*24) }
+            <<< DateRow("MaxDateRow_d1"){ $0.title = "Date(max)"; $0.value = Date(); $0.maximumDate = $0.value?.addingTimeInterval(60*60*24) }
+            <<< DateRow("MinMaxDateRow_d1"){ $0.title = "Date(min/max)"; $0.value = Date(); $0.minimumDate = $0.value?.addingTimeInterval(-60*60*24); $0.maximumDate = $0.value?.addingTimeInterval(60*60*24)  }
             <<< DateRow("IntervalDateRow_d1"){ $0.title = "Date(interval)"; $0.value = Date(); $0.minuteInterval = 15 }
         
         shortForm +++ Section("short")

--- a/Tests/BaseEurekaTests.swift
+++ b/Tests/BaseEurekaTests.swift
@@ -38,20 +38,21 @@ class BaseEurekaTests: XCTestCase {
         super.setUp()
         
         // load the view to test the cells
-        formVC.view.frame = CGRectMake(0, 0, 375, 3000)
+        
+        formVC.view.frame = CGRect(x: 0, y: 0, width: 375, height: 3000)
         formVC.tableView?.frame = formVC.view.frame
 
         
         // Create a Date section containing one date row of each type and some extra rows that use minimumDate, maximumDate and minuteInterval restrictions
         dateForm +++ Section("Date Section")
-            <<< DateRow("DateRow_d1"){ $0.title = "Date"; $0.value = NSDate() }
-            <<< DateTimeRow("DateTimeRow_d1"){ $0.title = "DateTime"; $0.value = NSDate() }
-            <<< TimeRow("TimeRow_d1"){ $0.title = "Time"; $0.value = NSDate() }
-            <<< CountDownRow("CountDownRow_d1"){ $0.title = "CountDown"; $0.value = NSDate() }
-            <<< DateRow("MinDateRow_d1"){ $0.title = "Date(min)"; $0.value = NSDate(); $0.minimumDate = $0.value?.dateByAddingTimeInterval(-60*60*24) }
-            <<< DateRow("MaxDateRow_d1"){ $0.title = "Date(max)"; $0.value = NSDate(); $0.maximumDate = $0.value?.dateByAddingTimeInterval(60*60*24) }
-            <<< DateRow("MinMaxDateRow_d1"){ $0.title = "Date(min/max)"; $0.value = NSDate(); $0.minimumDate = $0.value?.dateByAddingTimeInterval(-60*60*24); $0.maximumDate = $0.value?.dateByAddingTimeInterval(60*60*24)  }
-            <<< DateRow("IntervalDateRow_d1"){ $0.title = "Date(interval)"; $0.value = NSDate(); $0.minuteInterval = 15 }
+            <<< DateRow("DateRow_d1"){ $0.title = "Date"; $0.value = Date() }
+            <<< DateTimeRow("DateTimeRow_d1"){ $0.title = "DateTime"; $0.value = Date() }
+            <<< TimeRow("TimeRow_d1"){ $0.title = "Time"; $0.value = Date() }
+            <<< CountDownRow("CountDownRow_d1"){ $0.title = "CountDown"; $0.value = Date() }
+            <<< DateRow("MinDateRow_d1"){ $0.title = "Date(min)"; $0.value = Date(); $0.minimumDate = $0.value?.addTimeInterval(-60*60*24) }
+            <<< DateRow("MaxDateRow_d1"){ $0.title = "Date(max)"; $0.value = Date(); $0.maximumDate = $0.value?.addTimeInterval(60*60*24) }
+            <<< DateRow("MinMaxDateRow_d1"){ $0.title = "Date(min/max)"; $0.value = Date(); $0.minimumDate = $0.value?.addTimeInterval(-60*60*24); $0.maximumDate = $0.value?.addTimeInterval(60*60*24)  }
+            <<< DateRow("IntervalDateRow_d1"){ $0.title = "Date(interval)"; $0.value = Date(); $0.minuteInterval = 15 }
         
         shortForm +++ Section("short")
             <<< NameRow("NameRow_s1"){ $0.title = "Name" }

--- a/Tests/CallbacksTests.swift
+++ b/Tests/CallbacksTests.swift
@@ -45,9 +45,9 @@ class CallbacksTests: XCTestCase {
         onChangeTest(TextRow(), value: "text")
         onChangeTest(IntRow(), value: 33)
         onChangeTest(DecimalRow(), value: 35.7)
-        onChangeTest(URLRow(), value: NSURL(string: "http://xmartlabs.com")!)
-        onChangeTest(DateRow(), value: NSDate().dateByAddingTimeInterval(100))
-        onChangeTest(DateInlineRow(), value: NSDate().dateByAddingTimeInterval(100))
+        onChangeTest(URLRow(), value: URL(string: "http://xmartlabs.com")!)
+        onChangeTest(DateRow(), value: NSDate().addingTimeInterval(100) as Date)
+        onChangeTest(DateInlineRow(), value: NSDate().addingTimeInterval(100) as Date)
         onChangeTest(PopoverSelectorRow<String>(), value: "text")
         onChangeTest(PostalAddressRow(), value: PostalAddress(street: "a", state: "b", postalCode: "c", city: "d", country: "e"))
         onChangeTest(SliderRow(), value: 5.0)
@@ -119,7 +119,7 @@ class CallbacksTests: XCTestCase {
         defaultInitializerTest(StepperRow())
     }
     
-    private func onChangeTest<Row, Value where Row: BaseRow, Row: RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row, value:Value){
+    private func onChangeTest<Row, Value where Row: BaseRow, Row: RowType, Row: TypedRowType, Value == Row.Cell.Value>(_ row:Row, value:Value){
         var invoked = false
         row.onChange { row in
             invoked = true
@@ -129,27 +129,27 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func cellSetupTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row){
+    private func cellSetupTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(_ row:Row){
         var invoked = false
         row.cellSetup { cell, row in
             invoked = true
         }
         formVC.form +++ Section() <<< row
-        row.cell // laod cell
+        let _ = row.cell // load cell
         XCTAssertTrue(invoked)
     }
     
-    private func cellUpdateTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row){
+    private func cellUpdateTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(_ row:Row){
         var invoked = false
         row.cellUpdate { cell, row in
             invoked = true
         }
         formVC.form +++ Section() <<< row
-        formVC.tableView(formVC.tableView!, cellForRowAt: row.indexPath()!) // should invoke cell update
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: row.indexPath()!) // should invoke cell update
         XCTAssertTrue(invoked)
     }
     
-    private func defaultInitializerTest<Row where Row: BaseRow, Row : RowType,  Row: TypedRowType>(row:Row){
+    private func defaultInitializerTest<Row where Row: BaseRow, Row : RowType,  Row: TypedRowType>(_ row:Row){
         var invoked = false
         Row.defaultRowInitializer = { row in
             invoked = true
@@ -158,23 +158,23 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func defaultCellSetupTest<Row where Row: BaseRow, Row: RowType,  Row: TypedRowType>(row:Row){
+    private func defaultCellSetupTest<Row where Row: BaseRow, Row: RowType,  Row: TypedRowType>(_ row:Row){
         var invoked = false
         Row.defaultCellSetup = { cell, row in
             invoked = true
         }
         formVC.form +++ row
-        row.cell // laod cell
+        let _ = row.cell // load cell
         XCTAssertTrue(invoked)
     }
 
-    private func defaultCellUpdateTest<Row where Row: BaseRow, Row : RowType, Row: TypedRowType>(row:Row){
+    private func defaultCellUpdateTest<Row where Row: BaseRow, Row : RowType, Row: TypedRowType>(_ row:Row){
         var invoked = false
         Row.defaultCellUpdate = { cell, row in
             invoked = true
         }
         formVC.form +++ row
-        formVC.tableView(formVC.tableView!, cellForRowAt: row.indexPath()!) // should invoke cell update
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: row.indexPath()!) // should invoke cell update
         XCTAssertTrue(invoked)
     }
 }

--- a/Tests/CollectionTests.swift
+++ b/Tests/CollectionTests.swift
@@ -30,7 +30,7 @@ class CollectionTests: BaseEurekaTests {
     func testSectionRangeReplaceableCollectionTypeConformance() {
         // test if the collection function work as expected
         
-        fieldForm[0].replaceSubRange(subRange: 3...6, with: [CheckRow("check1_ctx")])          // replacing 4 rows with 1
+        fieldForm[0].replaceSubrange(Range(3...6), with: [CheckRow("check1_ctx")])          // replacing 4 rows with 1
         XCTAssertEqual(fieldForm[0].count, 8)                                                       // fieldform had 10 rows prior to replacing
         fieldForm[0][4] = CheckRow("check2_ctx")                                                    // replacing 5th row
         XCTAssertEqual(fieldForm[0].count, 8)
@@ -80,7 +80,7 @@ class CollectionTests: BaseEurekaTests {
         XCTAssertEqual(delegate.rowsAdded, 1)
         
         form[2][1] = TextRow("textrow7_ctx")                                                    // replacerowIn+1, replacerowOut+1,
-        form.replaceRange(0...1, with: [Section("replaced in")])              // replacesectionOut+1, sectionremoved+1, replacesectionin+1
+        form.replaceSubrange(0...1, with: [Section("replaced in")])              // replacesectionOut+1, sectionremoved+1, replacesectionin+1
         
         XCTAssertEqual(delegate.sectionsRemoved, 1)
         

--- a/Tests/CollectionTests.swift
+++ b/Tests/CollectionTests.swift
@@ -30,14 +30,14 @@ class CollectionTests: BaseEurekaTests {
     func testSectionRangeReplaceableCollectionTypeConformance() {
         // test if the collection function work as expected
         
-        fieldForm[0].replaceRange(3...6, with: [CheckRow("check1_ctx")])          // replacing 4 rows with 1
+        fieldForm[0].replaceSubRange(subRange: 3...6, with: [CheckRow("check1_ctx")])          // replacing 4 rows with 1
         XCTAssertEqual(fieldForm[0].count, 8)                                                       // fieldform had 10 rows prior to replacing
         fieldForm[0][4] = CheckRow("check2_ctx")                                                    // replacing 5th row
         XCTAssertEqual(fieldForm[0].count, 8)
         
         XCTAssertEqual(fieldForm[0].filter({ $0 is CheckRow }).count, 2)                            // Do I have 2 CheckRows??
 
-        fieldForm[0].appendContentsOf([CheckRow("check3_ctx"), CheckRow("check4_ctx"), CheckRow("check5_ctx")])
+        fieldForm[0].append(contentsOf: [CheckRow("check3_ctx"), CheckRow("check4_ctx"), CheckRow("check5_ctx")])
         // is the same as fieldForm[0] += [...]
         
         XCTAssertEqual(fieldForm[0].count, 11)
@@ -46,14 +46,14 @@ class CollectionTests: BaseEurekaTests {
     func testFormRangeReplaceableCollectionTypeConformance() {
         // test if the collection function work as expected
         
-        manySectionsForm.replaceRange(2..<5, with: [Section("Out of order"), Section()])         // replacing 3 rows with 2
+        manySectionsForm.replaceSubrange(2..<5, with: [Section("Out of order"), Section()])         // replacing 3 rows with 2
         XCTAssertEqual(manySectionsForm.count, 5)                                                                  // fieldform had 10 rows prior to replacing
         manySectionsForm[3] = Section("There is no order anyway")                                               // replacing 4th row
         XCTAssertEqual(manySectionsForm.count, 5)
         
-        XCTAssertEqual(manySectionsForm.filter({ $0.header?.title?.containsString("order") ?? false}).count, 2)
+        XCTAssertEqual(manySectionsForm.filter({ $0.header?.title?.contains("order") ?? false}).count, 2)
         
-        manySectionsForm.appendContentsOf([Section("1"), Section("2")])
+        manySectionsForm.append(contentsOf: [Section("1"), Section("2")])
         // is the same as fieldForm[0] += [...]
         
         XCTAssertEqual(manySectionsForm.count, 7)
@@ -61,7 +61,7 @@ class CollectionTests: BaseEurekaTests {
     
     func testDelegateFunctions() {
         // Test operators
-        let form = Form()
+        var form = Form()
         let delegate = MyFormDelegate()
         form.delegate = delegate
         

--- a/Tests/DateTests.swift
+++ b/Tests/DateTests.swift
@@ -54,12 +54,12 @@ class DateTests: BaseEurekaTests {
         formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: minMaxRow.indexPath()!)
         
         XCTAssertNil(minRow.cell.datePicker.maximumDate)
-        XCTAssertEqual(minRow.cell.datePicker.minimumDate, minRow.value?.dateByAddingTimeInterval(-60*60*24))
+        XCTAssertEqual(minRow.cell.datePicker.minimumDate, minRow.value?.addTimeInterval(-60*60*24))
         XCTAssertNil(maxRow.cell.datePicker.minimumDate)
-        XCTAssertEqual(maxRow.cell.datePicker.maximumDate, maxRow.value?.dateByAddingTimeInterval(60*60*24))
+        XCTAssertEqual(maxRow.cell.datePicker.maximumDate, maxRow.value?.addTimeInterval(60*60*24))
         
         XCTAssertNotNil(minMaxRow.cell.datePicker.minimumDate)
-        XCTAssertEqual(minMaxRow.cell.datePicker.maximumDate, minMaxRow.cell.datePicker.minimumDate!.dateByAddingTimeInterval(2*60*60*24))
+        XCTAssertEqual(minMaxRow.cell.datePicker.maximumDate, minMaxRow.cell.datePicker.minimumDate?.addTimeInterval(2*60*60*24))
     }
     
     func testInterval(){

--- a/Tests/DateTests.swift
+++ b/Tests/DateTests.swift
@@ -54,12 +54,12 @@ class DateTests: BaseEurekaTests {
         let _ = formVC.tableView(formVC.tableView!, cellForRowAt: minMaxRow.indexPath()!)
         
         XCTAssertNil(minRow.cell.datePicker.maximumDate)
-        XCTAssertEqual(minRow.cell.datePicker.minimumDate, minRow.value?.addTimeInterval(-60*60*24))
+        XCTAssertEqual(minRow.cell.datePicker.minimumDate, minRow.value?.addingTimeInterval(-60*60*24))
         XCTAssertNil(maxRow.cell.datePicker.minimumDate)
-        XCTAssertEqual(maxRow.cell.datePicker.maximumDate, maxRow.value?.addTimeInterval(60*60*24))
+        XCTAssertEqual(maxRow.cell.datePicker.maximumDate, maxRow.value?.addingTimeInterval(60*60*24))
         
         XCTAssertNotNil(minMaxRow.cell.datePicker.minimumDate)
-        XCTAssertEqual(minMaxRow.cell.datePicker.maximumDate, minMaxRow.cell.datePicker.minimumDate?.addTimeInterval(2*60*60*24))
+        XCTAssertEqual(minMaxRow.cell.datePicker.maximumDate, minMaxRow.cell.datePicker.minimumDate!.addingTimeInterval(2*60*60*24))
     }
     
     func testInterval(){

--- a/Tests/DateTests.swift
+++ b/Tests/DateTests.swift
@@ -44,14 +44,14 @@ class DateTests: BaseEurekaTests {
         XCTAssertNotNil(minMaxRow.indexPath())
         
         // make sure cellSetup is called for each cell
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: minRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: maxRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: minMaxRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: minRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: maxRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: minMaxRow.indexPath()!)
         
         //make sure cell update is called for each cell
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: minRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: maxRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: minMaxRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: minRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: maxRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: minMaxRow.indexPath()!)
         
         XCTAssertNil(minRow.cell.datePicker.maximumDate)
         XCTAssertEqual(minRow.cell.datePicker.minimumDate, minRow.value?.addTimeInterval(-60*60*24))
@@ -68,10 +68,10 @@ class DateTests: BaseEurekaTests {
         XCTAssertNotNil(row?.indexPath())
         
         // make sure cellSetup is called for each cell
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: row!.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: row!.indexPath()!)
         
         //make sure cell update is called for each cell
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: row!.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: row!.indexPath()!)
         
         XCTAssertEqual(row?.cell.datePicker.minuteInterval, 15)
 

--- a/Tests/HelperMethodTests.swift
+++ b/Tests/HelperMethodTests.swift
@@ -98,14 +98,14 @@ class HelperMethodTests: BaseEurekaTests {
         formVC.form +++ checkRow <<< switchRow <<< segmentedRow <<< intRow
         
         checkRow.updateCell()
-        XCTAssertTrue(checkRow.cell.selectionStyle == .None)
+        XCTAssertTrue(checkRow.cell.selectionStyle == .none)
         
         switchRow.updateCell()
         XCTAssertNotNil(switchRow.cell.switchControl)
-        XCTAssertFalse(switchRow.cell.switchControl!.enabled)
+        XCTAssertFalse(switchRow.cell.switchControl!.isEnabled)
         
         segmentedRow.updateCell()
-        XCTAssertFalse(segmentedRow.cell.segmentedControl.enabled)
+        XCTAssertFalse(segmentedRow.cell.segmentedControl.isEnabled)
         
         intRow.updateCell()
         XCTAssertFalse(intRow.cell.cellCanBecomeFirstResponder())

--- a/Tests/HelperMethodTests.swift
+++ b/Tests/HelperMethodTests.swift
@@ -47,7 +47,7 @@ class HelperMethodTests: BaseEurekaTests {
         XCTAssertEqual(row6, form.rowByTag("IntRow_f1") as? IntRow)
         
         
-        let row_5_and_6: MutableSlice<Section> = form[0][5...6]
+        let row_5_and_6: MutableSlice<Section> = form[0][Range(5...6)]
         XCTAssertEqual(row_5_and_6[5], form[0][5])
         XCTAssertEqual(row_5_and_6[6], form[0][6])
         

--- a/Tests/HiddenRowsTests.swift
+++ b/Tests/HiddenRowsTests.swift
@@ -251,8 +251,8 @@ class HiddenRowsTests: BaseEurekaTests {
                     $0.hidden = "$NameRow_s1 contains 'morning'"
                     $0.tag = "s2_ths"
                 }
-        form.insert(s1, atIndex: 1)
-        form.insert(s2, atIndex: 3)
+        form.insert(s1, at: 1)
+        form.insert(s2, at: 3)
         
         /* what we should have here
         
@@ -291,8 +291,8 @@ class HiddenRowsTests: BaseEurekaTests {
         let r3 = CheckRow("check3_tii_hrt"){ $0.hidden = "$NameRow_s1 contains 'good'" }
         let r4 = CheckRow("check4_tii_hrt"){ $0.hidden = "$NameRow_s1 contains 'good'" }
         
-        form[0].insert(r1, atIndex: 1)
-        form[1].insertContentsOf([r2,r3], at: 0)
+        form[0].insert(r1, at: 1)
+        form[1].insert(contentsOf: [r2,r3], at: 0)
         
         //test correct insert
         
@@ -307,7 +307,7 @@ class HiddenRowsTests: BaseEurekaTests {
         form[0][0].baseValue = "hello, good morning!"
         
         // insert another row
-        form[1].insert(r4, atIndex: 1)
+        form[1].insert(r4, at: 1)
         
         XCTAssertEqual(form[1].count, 2) // all inserted rows should be hidden
         XCTAssertEqual(form[1][0].tag, "int1_hrt")
@@ -329,7 +329,7 @@ class HiddenRowsTests: BaseEurekaTests {
         form[1].removeAll()
         
         //inserting 2 rows at the end, deleting 1
-        form[2].replaceRange(1..<2, with: [r2, r4])
+        form[2].replaceSubrange(1..<2, with: [r2, r4])
         
         XCTAssertEqual(form[1].count, 0)
         XCTAssertEqual(form[2].count, 1)

--- a/Tests/HiddenRowsTests.swift
+++ b/Tests/HiddenRowsTests.swift
@@ -30,10 +30,11 @@ class HiddenRowsTests: BaseEurekaTests {
     let row10 = IntRow("int1_hrt"){
         $0.hidden = "$IntRow_s1 > 23"
     }
+    
     let row11 = TextRow("txt1_hrt"){
-        $0.hidden = .Function(["NameRow_s1"], { form in
+        $0.hidden = .function(["NameRow_s1"], { form in
                         if let r1 : NameRow = form.rowByTag("NameRow_s1") {
-                            return r1.value?.containsString(" is ") ?? false
+                            return r1.value?.contains(" is ") ?? false
                         }
                         return false
                     })
@@ -43,7 +44,7 @@ class HiddenRowsTests: BaseEurekaTests {
         $0.hidden = "$NameRow_s1 contains 'God'"
     }
     let row20 = TextRow("txt2_hrt"){
-        $0.hidden = .Function(["IntRow_s1", "NameRow_s1"], { form in
+        $0.hidden = .function(["IntRow_s1", "NameRow_s1"], { form in
                         if let r1 : IntRow = form.rowByTag("IntRow_s1"), let r2 : NameRow = form.rowByTag("NameRow_s1")  {
                             return r1.value == 88 || r2.value?.hasSuffix("real") ?? false
                         }
@@ -66,8 +67,8 @@ class HiddenRowsTests: BaseEurekaTests {
 
     func testAddRowToObserver(){
         
-        let intDep = form.rowObservers["IntRow_s1"]?[.Hidden]
-        let nameDep = form.rowObservers["NameRow_s1"]?[.Hidden]
+        let intDep = form.rowObservers["IntRow_s1"]?[.hidden]
+        let nameDep = form.rowObservers["NameRow_s1"]?[.hidden]
         
         // make sure we can unwrap
         XCTAssertNotNil(intDep)

--- a/Tests/RowCallbackTests.swift
+++ b/Tests/RowCallbackTests.swift
@@ -33,7 +33,7 @@ class RowCallbackTests: BaseEurekaTests {
             +++ Section("something")
             <<< CheckRow("row1").cellSetup { cell, row in
                 cell.textLabel?.text = "checkrow + Setup"
-                cell.backgroundColor = .redColor()
+                cell.backgroundColor = .red()
             }
             <<< IntRow("row2").cellUpdate({ cell, row in
                 cell.textLabel?.text = "introw"
@@ -101,7 +101,7 @@ class RowCallbackTests: BaseEurekaTests {
         XCTAssertEqual(intRow?.cell.textLabel?.text, "introw")
         XCTAssertEqual(textRow?.cell.textLabel?.text, "afterupdate")
         
-        XCTAssertEqual(chkRow?.cell.backgroundColor, .redColor())
+        XCTAssertEqual(chkRow?.cell.backgroundColor, .red())
         XCTAssertEqual(intRow?.cell.textLabel?.font, UIFont(name: "Baskerville-Italic", size: 20))
         XCTAssertEqual(textRow?.cell.textLabel?.font, UIFont(name: "Baskerville-Italic", size: 20))
         

--- a/Tests/RowCallbackTests.swift
+++ b/Tests/RowCallbackTests.swift
@@ -82,20 +82,20 @@ class RowCallbackTests: BaseEurekaTests {
         
         // make sure cellSetup is called for each cell
         
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: intRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: intRow.indexPath()!)
         
         
         XCTAssertEqual(chkRow.cell.textLabel?.text, "checkrow + Setup")
         XCTAssertEqual(textRow.cell.textLabel?.text, "aftersetup")
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: textRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: textRow.indexPath()!)
         XCTAssertEqual(textRow.cell.textLabel?.text, "afterupdate")
         
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: chkRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: chkRow.indexPath()!)
         
         //make sure cell update is called for each cell
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: chkRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: intRow.indexPath()!)
-        formVC.tableView(formVC.tableView!, cellForRowAtIndexPath: textRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: chkRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: intRow.indexPath()!)
+        let _ = formVC.tableView(formVC.tableView!, cellForRowAt: textRow.indexPath()!)
         
         XCTAssertEqual(chkRow?.cell.textLabel?.text, chkRow?.title)
         XCTAssertEqual(intRow?.cell.textLabel?.text, "introw")


### PR DESCRIPTION
## What it does

- Fully converts to Swift 3 syntax for framework, project, and tests.

## What it doesn't do

Pass all the tests. There are two test failures:
1. CollectionTests - `testDelegateFunctions()`
2. HiddenRowTests - `testHiddenSections()`

## How to test

Run the project, run the tests.

## Notes

Don't understand the Eureka codebase enough, so I didn't want to try to fix the tests.
