### PR TITLE
Deselection changes

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -668,7 +668,9 @@ class NativeEventFormViewController : FormViewController {
                     $0.title = $0.tag
                     $0.options = RepeatInterval.allValues
                     $0.value = .Never
-                }
+                }.onPresent({ (_, vc) in
+                    vc.enableDeselection = false
+                })
         
         form +++
             

--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -92,15 +92,20 @@ extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIt
                     case .multipleSelection:
                         row.value = row.value == nil ? row.selectableValue : nil
                         row.updateCell()
+                        s.onSelectSelectableRow?(cell, row)
                     case .singleSelection(let enableDeselection):
                         s.filter { $0.baseValue != nil && $0 != row }.forEach {
                             $0.baseValue = nil
                             $0.updateCell()
                         }
-                        row.value = !enableDeselection || row.value == nil ? row.selectableValue : nil
-                        row.updateCell()
+                        // Check if row is not already selected
+                        if enableDeselection || row.value == nil {
+                            row.value = row.value == nil ? row.selectableValue : nil
+                            row.updateCell()
+                            s.onSelectSelectableRow?(cell, row)
+                        }
                     }
-                    s.onSelectSelectableRow?(cell, row)
+                    
                 }
             }
         }

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -12,6 +12,7 @@ public class _SelectorViewController<Row: SelectableRowType where Row: BaseRow, 
     
     /// The row that pushed or presented this controller
     public var row: RowOf<Row.Cell.Value>!
+    public var enableDeselection = true
     
     /// A closure to be called when the controller disappears.
     public var completionCallback : ((UIViewController) -> ())?
@@ -30,7 +31,7 @@ public class _SelectorViewController<Row: SelectableRowType where Row: BaseRow, 
         super.viewDidLoad()
         guard let options = row.dataProvider?.arrayData else { return }
         
-        form +++ SelectableSection<Row>(row.title ?? "", selectionType: .singleSelection(enableDeselection: true)) { [weak self] section in
+        form +++ SelectableSection<Row>(row.title ?? "", selectionType: .singleSelection(enableDeselection: enableDeselection)) { [weak self] section in
             if let sec = section as? SelectableSection<Row> {
                 sec.onSelectSelectableRow = { _, row in
                     self?.row.value = row.value


### PR DESCRIPTION
onSelectSelectableRow will not be called when nothing changes
 (when `enableDeselection = false` and user deselects a row)

Added enableDeselection customisation parameter to SelectorViewController