### PR TITLE
Make `completionHandler` public in PresentationMode for subclassing purpose

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -157,7 +157,7 @@ public enum PresentationMode<VCType: UIViewController> {
     case Popover(controllerProvider: ControllerProvider<VCType>, completionCallback: (UIViewController->())?)
     
     
-    var completionHandler: (UIViewController ->())? {
+    public var completionHandler: (UIViewController ->())? {
         switch self{
             case .Show(_, let completionCallback):
                 return completionCallback


### PR DESCRIPTION
Hi,

For a specific project I need to create an equivalent of `GenericMultipleSelectorRow` with specific features.

However I can't access to the `presentationMode?.completionHandler` because it is internal. So I just make the `completionHandler` public in order to have access to this property outside the Eureka framework.

Best,

Yannick