### PR TITLE
Also clear imageURL when clearing the row

### DIFF
--- a/Source/Rows/ImageRow.swift
+++ b/Source/Rows/ImageRow.swift
@@ -120,6 +120,7 @@ public class _ImageRow<Cell: CellType where Cell: BaseCell, Cell: TypedCellType,
         if case .yes(let style) = clearAction, value != nil {
             let clearPhotoOption = UIAlertAction(title: NSLocalizedString("Clear Photo", comment: ""), style: style, handler: { [weak self] _ in
                 self?.value = nil
+                self?.imageURL = nil
                 self?.updateCell()
                 })
             sourceActionSheet.addAction(clearPhotoOption)


### PR DESCRIPTION
Right now when using the clear action on an ImageRow only the value of the row is set to nil. The property imageURL should also be resetted.