### PR TITLE
(StepperRow) Moved stepper and valueLabel update code from setup() to update()

### DIFF
--- a/Source/Rows/StepperRow.swift
+++ b/Source/Rows/StepperRow.swift
@@ -42,12 +42,10 @@ public class StepperCell : Cell<Double>, CellType {
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:[v]-[s]-|", options: .AlignAllCenterY, metrics: nil, views: ["s": stepper, "v": valueLabel]))
         addConstraint(NSLayoutConstraint(item: stepper, attribute: .CenterY, relatedBy: .Equal, toItem: contentView, attribute: .CenterY, multiplier: 1.0, constant: 0))
         addConstraint(NSLayoutConstraint(item: valueLabel, attribute: .CenterY, relatedBy: .Equal, toItem: stepper, attribute: .CenterY, multiplier: 1.0, constant: 0))
-        
-        stepper.addTarget(self, action: #selector(StepperCell.valueChanged), forControlEvents: .ValueChanged)
-        stepper.value = row.value ?? 0
-        
+
         valueLabel.textColor = stepper.tintColor
-        valueLabel.text = "\(row.value ?? 0)"
+
+        stepper.addTarget(self, action: #selector(StepperCell.valueChanged), forControlEvents: .ValueChanged)
     }
     
     deinit {
@@ -56,6 +54,8 @@ public class StepperCell : Cell<Double>, CellType {
     
     public override func update() {
         super.update()
+        stepper.value = row.value ?? 0
+        valueLabel.text = "\(row.value ?? 0)"
         stepper.enabled = !row.isDisabled
         stepper.alpha = row.isDisabled ? 0.3 : 1.0
         valueLabel.alpha = row.isDisabled ? 0.3 : 1.0


### PR DESCRIPTION
Stepper row wasn't updating the controls when changing the value from setValues(values: [String: Any?]). I moved the UI update code from the cell setup code to the cell update code and now it works as intended (in my opinion at least, other rows has this behaviour as well). I believe it's already covered by test cases.