### PR TITLE
Fix predicate evaluation when values include Optional and or nil

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -164,7 +164,7 @@ extension BaseRow {
         if let t = tag {
             assert(section.form?.rowsByTag[t] == nil, "Duplicate tag \(t)")
             self.section?.form?.rowsByTag[t] = self
-            self.section?.form?.tagToValues[t] = baseValue as AnyObject
+            self.section?.form?.tagToValues[t] = baseValue != nil ? baseValue! : NSNull()
         }
         addToRowObservers()
         evaluateHidden()

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -160,7 +160,7 @@ public final class Form {
     
     var rowObservers = [String: [ConditionType: [Taggable]]]()
     var rowsByTag = [String: BaseRow]()
-    var tagToValues = [String: AnyObject]()
+    var tagToValues = [String: Any]()
     lazy var kvoWrapper : KVOWrapper = { [unowned self] in return KVOWrapper(form: self) }()
 }
 
@@ -289,7 +289,7 @@ extension Form {
         }
     }
     
-    func dictionaryValuesToEvaluatePredicate() -> [String: AnyObject] {
+    func dictionaryValuesToEvaluatePredicate() -> [String: Any] {
         return tagToValues
     }
     

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -37,7 +37,7 @@ open class RowOf<T: Equatable>: BaseRow {
                 callbackOnChange?()
             }
             guard let t = tag else { return }
-            form.tagToValues[t] = (value as AnyObject) 
+            form.tagToValues[t] = (value != nil ? value! : NSNull())
             if let rowObservers = form.rowObservers[t]?[.hidden]{
                 for rowObserver in rowObservers {
                     (rowObserver as? Hidable)?.evaluateHidden()

--- a/Tests/CallbacksTests.swift
+++ b/Tests/CallbacksTests.swift
@@ -119,7 +119,7 @@ class CallbacksTests: XCTestCase {
        defaultInitializerTest(row: StepperRow())
     }
     
-    private func onChangeTest<Row, Value where Row: BaseRow, Row: RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row, value:Value){
+    private func onChangeTest<Row, Value>(row:Row, value:Value) where Row: BaseRow, Row: RowType, Row: TypedRowType, Value == Row.Cell.Value {
         var invoked = false
         row.onChange { row in
             invoked = true
@@ -129,7 +129,7 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func cellSetupTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row){
+    private func cellSetupTest<Row, Value>(row:Row) where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value {
         var invoked = false
         row.cellSetup { cell, row in
             invoked = true
@@ -139,7 +139,7 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func cellUpdateTest<Row, Value where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value>(row:Row){
+    private func cellUpdateTest<Row, Value>(row:Row) where  Row: BaseRow, Row : RowType, Row: TypedRowType, Value == Row.Cell.Value {
         var invoked = false
         row.cellUpdate { cell, row in
             invoked = true
@@ -149,7 +149,7 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func defaultInitializerTest<Row where Row: BaseRow, Row : RowType,  Row: TypedRowType>(row:Row){
+    private func defaultInitializerTest<Row>(row:Row) where Row: BaseRow, Row : RowType,  Row: TypedRowType {
         var invoked = false
         Row.defaultRowInitializer = { row in
             invoked = true
@@ -158,7 +158,7 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
     
-    private func defaultCellSetupTest<Row where Row: BaseRow, Row: RowType,  Row: TypedRowType>(row:Row){
+    private func defaultCellSetupTest<Row>(row:Row) where Row: BaseRow, Row: RowType,  Row: TypedRowType {
         var invoked = false
         Row.defaultCellSetup = { cell, row in
             invoked = true
@@ -168,7 +168,7 @@ class CallbacksTests: XCTestCase {
         XCTAssertTrue(invoked)
     }
 
-    private func defaultCellUpdateTest<Row where Row: BaseRow, Row : RowType, Row: TypedRowType>(row:Row){
+    private func defaultCellUpdateTest<Row>(row:Row) where Row: BaseRow, Row : RowType, Row: TypedRowType {
         var invoked = false
         Row.defaultCellUpdate = { cell, row in
             invoked = true

--- a/Tests/HiddenRowsTests.swift
+++ b/Tests/HiddenRowsTests.swift
@@ -73,7 +73,7 @@ class HiddenRowsTests: BaseEurekaTests {
         // make sure we can unwrap
         XCTAssertNotNil(intDep)
         XCTAssertNotNil(nameDep)
-        
+
         // test rowObservers
         XCTAssertEqual(intDep!.count, 3)
         XCTAssertEqual(nameDep!.count, 3)
@@ -117,6 +117,14 @@ class HiddenRowsTests: BaseEurekaTests {
         XCTAssertTrue(nameDep!.contains(where: { $0.tag == "s3_hrt" }))
         XCTAssertTrue(nameDep!.contains(where: { $0.tag == "txt1_hrt" }))
         XCTAssertFalse(nameDep!.contains(where: { $0.tag == "int1_hrt" }))
+
+        // Test a condition with nil
+        let newRow = TextRow("new_row") {
+            $0.hidden = "$txt1_hrt == nil"
+        }
+
+        form.last! <<< newRow
+        XCTAssertTrue(newRow.hiddenCache)
     }
     
     func testItemsByTag(){


### PR DESCRIPTION
Changed internal variables `tagToValues` to be [String: Any] as values are Any and NSPredicates require Any. No need to cast to `AnyObject` anymore
If the value of a row is nil, we now insert `NSNull()` into this dictionary

@xmartlabs/eureka 