### PR TITLE
Make the PresentationMode.completionHandler public like in the Swift2.2 branch

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -157,7 +157,7 @@ public enum PresentationMode<VCType: UIViewController> {
     case Popover(controllerProvider: ControllerProvider<VCType>, completionCallback: (UIViewController->())?)
     
     
-    var completionHandler: (UIViewController ->())? {
+    public var completionHandler: (UIViewController ->())? {
         switch self{
             case .Show(_, let completionCallback):
                 return completionCallback


### PR DESCRIPTION
Everything is told in the title.

In the swift2.2 branch the `PresentationMode.completionHandler` property is public while in the swift2.3 no.

I need this property to be public for my project that I updated to Swift2.3 waiting for the Swift3 migration of all the dependencies.