### PR TITLE
Change the access control to open for some classes and methods

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 			name = SelectableRows;
 			sourceTree = "<group>";
 		};
-		287E7D7C1D62552C0065F4DE /* Valiadtions */ = {
+		287E7D7C1D62552C0065F4DE /* Validations */ = {
 			isa = PBXGroup;
 			children = (
 				287E7D7D1D625A260065F4DE /* RuleRequired.swift */,
@@ -304,7 +304,7 @@
 				287E7D8F1D7601850065F4DE /* RuleLength.swift */,
 				280FBE5E1D873CCE00900064 /* RuleClosure.swift */,
 			);
-			name = Valiadtions;
+			name = Validations;
 			sourceTree = "<group>";
 		};
 		51729DE11B9A4F5E004A00EB = {
@@ -330,7 +330,7 @@
 			children = (
 				2859CD901C7CF1FD0002982F /* Core */,
 				2859CD971C7CF2020002982F /* Rows */,
-				287E7D7C1D62552C0065F4DE /* Valiadtions */,
+				287E7D7C1D62552C0065F4DE /* Validations */,
 				8690E4BC1CFDE02A004CDB1C /* Resources */,
 				51729E661B9A5FA5004A00EB /* Eureka.h */,
 				51729DF01B9A4F5E004A00EB /* Info.plist */,

--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -112,7 +112,7 @@ open class BaseRow : BaseRowType {
      */
     public func didSelect() {}
     
-    public func prepareForSegue(_ segue: UIStoryboardSegue) {}
+    open func prepareForSegue(_ segue: UIStoryboardSegue) {}
     
     /**
      Returns the NSIndexPath where this row is in the current form.

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -178,11 +178,11 @@ open class Row<Cell: CellType>: RowOf<Cell.Value>, TypedRowType where Cell: Base
     /**
      Will be called inside `didSelect` method of the row. Can be used to customize row selection from the definition of the row.
      */
-    public func customDidSelect(){}
+    open func customDidSelect(){}
 
     /**
      Will be called inside `updateCell` method of the row. Can be used to customize reloading a row from its definition.
      */
-    public func customUpdateCell(){}
+    open func customUpdateCell(){}
 
 }

--- a/Source/Rows/Common/SelectorRow.swift
+++ b/Source/Rows/Common/SelectorRow.swift
@@ -58,7 +58,7 @@ open class SelectorRow<Cell: CellType, VCType: TypedRowControllerType>: OptionsR
     /**
      Extends `didSelect` method
      */
-    public override func customDidSelect() {
+    open override func customDidSelect() {
         super.customDidSelect()
         guard let presentationMode = presentationMode, !isDisabled else { return }
         if let controller = presentationMode.createController(){
@@ -75,7 +75,7 @@ open class SelectorRow<Cell: CellType, VCType: TypedRowControllerType>: OptionsR
     /**
      Prepares the pushed row setting its title and completion callback.
      */
-    public override func prepareForSegue(_ segue: UIStoryboardSegue) {
+    open override func prepareForSegue(_ segue: UIStoryboardSegue) {
         super.prepareForSegue(segue)
         guard let rowVC = segue.destination as? VCType else { return }
         rowVC.title = selectorTitle ?? rowVC.title


### PR DESCRIPTION
Hi,

This pull request just aims to open some classes and methods in order to be able to subclass them properly. For example for the `Row` class I've opened the `customDidSelect` and `customUpdateCell ` methods.