### PR TITLE
Changing access level of keyboardWillShow and keyboardWillHide methods

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -820,7 +820,7 @@ extension FormViewController {
     /**
     Called when the keyboard will appear. Adjusts insets of the tableView and scrolls it if necessary.
     */
-    public func keyboardWillShow(_ notification: Notification){
+    open func keyboardWillShow(_ notification: Notification){
         guard let table = tableView, let cell = table.findFirstResponder()?.formCell() else { return }
         let keyBoardInfo = notification.userInfo!
         let endFrame = keyBoardInfo[UIKeyboardFrameEndUserInfoKey] as! NSValue
@@ -848,7 +848,7 @@ extension FormViewController {
     /**
      Called when the keyboard will disappear. Adjusts insets of the tableView.
      */
-    public func keyboardWillHide(_ notification: Notification){
+    open func keyboardWillHide(_ notification: Notification){
         guard let table = tableView,  let oldBottom = oldBottomInset else  { return }
         let keyBoardInfo = notification.userInfo!
         var tableInsets = table.contentInset


### PR DESCRIPTION
In swift2 version of eureka we can override this methods for custom logic. This pull request returns those opportunities.