### PR TITLE
Convert ProvisioningStyle to Automatic

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 					51729DEA1B9A4F5E004A00EB = {
 						CreatedOnToolsVersion = 7.0;
 						LastSwiftMigration = 0800;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					51729DF41B9A4F5E004A00EB = {
 						CreatedOnToolsVersion = 7.0;


### PR DESCRIPTION
Provisioning style 'Automatic' is the most consumer friendly provisioning style for frameworks. It permits the host project to dictate the provisioning style. 
Otherwise if a host project specifies Manual provisioning style, xcodebuild will fail when attempting to compile the subproject with: 
> Eureka does not support provisioning profiles. Eureka does not support provisioning profiles, but provisioning profile <defined provisioning profile> has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.