### PR TITLE
Fix variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ Sometimes the collection of rules we want to use on a row is the same we want to
 
 ```swift
 var rules = RuleSet<String>()
-ruleSet.add(rule: RuleRequired())
-ruleSet.add(rule: RuleEmail())
+rules.add(rule: RuleRequired())
+rules.add(rule: RuleEmail())
 
 let row = TextRow() {
             $0.title = "Email Rule"


### PR DESCRIPTION
Example code used undeclared variable `ruleSet`
