### PR TITLE
Fix UINavigationController interactive pop gesture could cause navbar blink and toolbar animation interruption

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -498,7 +498,7 @@ open class FormViewController : UIViewController, FormViewControllerProtocol {
         }
 
         if let coordinator = transitionCoordinator {
-            coordinator.animateAlongsideTransition(in: parent?.view, animation: deselectionAnimation, completion: reselection)
+            coordinator.animate(alongsideTransition: deselectionAnimation, completion: reselection)
         }
         else {
             selectedIndexPaths.forEach {


### PR DESCRIPTION
use workaround issued in #783.