### PR TITLE
Fix bug: if inserted text that has yet to be confirmed by the user update cell will cause lost typing info.

### DIFF
--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -57,6 +57,17 @@ open class RowOf<T: Equatable>: BaseRow {
             guard let _ = section?.form else { return }
             wasChanged = true
             if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || !isValid   {
+
+                if let textInput = (baseCell as? TextInputCell)?.textInput {
+                    if let makredRange = textInput.markedTextRange {
+                        if let length = textInput.text(in: makredRange)?.lengthOfBytes(using: .utf8) {
+
+                            // typing chinese use `pingyin` input method. DO NOT update cell. After user confirm it then update. 
+                            if length > 0 { return }
+                        }
+                    }
+                }
+
                 validate()
                 updateCell()
             }


### PR DESCRIPTION
Fix bug: if inserted text that has yet to be confirmed by the user update cell will cause lost typing info.
![bug](https://cloud.githubusercontent.com/assets/5820203/20749570/cf6926ba-b72d-11e6-9b82-2039b78028e2.gif)

