### PR TITLE
Fixed dependency on the method formViewController(), subclassing of FormViewController not necessary anymore.

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		082E31F21DF8DA1D005CFC85 /* PDFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082E31F11DF8DA1D005CFC85 /* PDFormViewModel.swift */; };
 		2837E2A01BA3A5A800A1952C /* FloatLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2837E29E1BA3A5A800A1952C /* FloatLabelTextField.swift */; };
 		285F2B441BB79B86005991BA /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 285F2B431BB79B86005991BA /* MapKit.framework */; };
 		287A143F1D99A96100FFE6EB /* ImagePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287A143D1D99A96100FFE6EB /* ImagePickerController.swift */; };
@@ -77,6 +78,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		082E31F11DF8DA1D005CFC85 /* PDFormViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDFormViewModel.swift; sourceTree = "<group>"; };
 		2837E29E1BA3A5A800A1952C /* FloatLabelTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = FloatLabelTextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		285F2B431BB79B86005991BA /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		287A143D1D99A96100FFE6EB /* ImagePickerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImagePickerController.swift; path = Example/CustomRows/ImageRow/ImagePickerController.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				51729E6A1B9A657E004A00EB /* Custom Row and Cell */,
 				51729E1D1B9A54F1004A00EB /* AppDelegate.swift */,
 				51729E1F1B9A54F1004A00EB /* ViewController.swift */,
+				082E31F11DF8DA1D005CFC85 /* PDFormViewModel.swift */,
 				51729E211B9A54F1004A00EB /* Main.storyboard */,
 				51729E241B9A54F1004A00EB /* Assets.xcassets */,
 				51729E261B9A54F1004A00EB /* LaunchScreen.storyboard */,
@@ -353,6 +356,7 @@
 				287A143F1D99A96100FFE6EB /* ImagePickerController.swift in Sources */,
 				51729E1E1B9A54F1004A00EB /* AppDelegate.swift in Sources */,
 				2837E2A01BA3A5A800A1952C /* FloatLabelTextField.swift in Sources */,
+				082E31F21DF8DA1D005CFC85 /* PDFormViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11191" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="6g3-M9-WkD">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="6g3-M9-WkD">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,6 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="jQG-xm-oMp">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -37,7 +41,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qff-bS-Fd6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="786" y="-385"/>
+            <point key="canvasLocation" x="543" y="-566"/>
         </scene>
         <!--Eureka! Rows Example-->
         <scene sceneID="bWN-GL-dH9">
@@ -52,6 +56,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="mHC-X5-7oy">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -70,7 +75,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w7K-pv-5uH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1194" y="-385"/>
+            <point key="canvasLocation" x="1118" y="-485"/>
         </scene>
         <!--Add Event-->
         <scene sceneID="tne-QT-ifu">
@@ -85,6 +90,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="oJ1-ro-hyM">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -138,6 +144,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="pl1-EZ-WGm">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -163,6 +170,7 @@
                         <segue destination="42E-0V-OKN" kind="push" identifier="InlineRowsControllerSegue" id="sMp-yV-Evw"/>
                         <segue destination="3b9-rf-NW3" kind="push" identifier="ListSectionsControllerSegue" id="s7W-Vn-beG"/>
                         <segue destination="1By-iT-GXN" kind="push" identifier="ValidationsControllerSegue" id="e8a-Jy-4iL"/>
+                        <segue destination="Lu6-zz-7Df" kind="push" identifier="PDTESTExampleViewControllerSegue" id="oDN-GZ-NXF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Eoz-Jq-Zy9" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -182,6 +190,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Pne-fE-n6D">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -233,6 +242,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Oyg-dY-W55">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -266,6 +276,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="i3R-XH-1m6">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -299,6 +310,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="UtE-Tw-uxw">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -332,6 +344,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hQM-hF-1JF">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -365,6 +378,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="dbo-b8-KHY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -398,6 +412,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ug4-ix-2ET">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -431,6 +446,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Sbj-p4-BRo">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </tableView>
                         </subviews>
@@ -450,6 +466,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L7e-b8-eJH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="859" y="1833"/>
+        </scene>
+        <!--PDTEST-->
+        <scene sceneID="xPe-0x-MI0">
+            <objects>
+                <viewController storyboardIdentifier="PDTESTExampleViewController" title="Eureka! Rows Example" id="Lu6-zz-7Df" userLabel="PDTEST" customClass="PDTESTExampleViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="9My-R3-lFU"/>
+                        <viewControllerLayoutGuide type="bottom" id="RlP-Yy-Ihv"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Bv0-09-kZj">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="XjZ-pl-tg6"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="auT-X3-uae" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1756" y="-567"/>
         </scene>
     </scenes>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">

--- a/Example/Example/CustomCells.swift
+++ b/Example/Example/CustomCells.swift
@@ -253,7 +253,7 @@ public class _FloatLabelCell<T>: Cell<T>, UITextFieldDelegate, TextFieldCell whe
     //MARK: TextFieldDelegate
     
     public func textFieldDidBeginEditing(_ textField: UITextField) {
-        formViewController()?.beginEditing(of: self)
+        formViewDelegate?.beginEditing(of: self)
         if let fieldRowConformance = row as? FormatterConformance, let _ = fieldRowConformance.formatter, fieldRowConformance.useFormatterOnDidBeginEditing ?? fieldRowConformance.useFormatterDuringInput {
             textField.text = displayValue(useFormatter: true)
         } else {
@@ -262,8 +262,8 @@ public class _FloatLabelCell<T>: Cell<T>, UITextFieldDelegate, TextFieldCell whe
     }
     
     public func textFieldDidEndEditing(_ textField: UITextField) {
-        formViewController()?.endEditing(of: self)
-        formViewController()?.textInputDidEndEditing(textField, cell: self)
+        formViewDelegate?.endEditing(of: self)
+        formViewDelegate?.textInputDidEndEditing(textField, cell: self)
         textFieldDidChange(textField)
         textField.text = displayValue(useFormatter: (row as? FormatterConformance)?.formatter != nil)
     }

--- a/Example/Example/CustomRows/ImageRow/ImageRow.swift
+++ b/Example/Example/CustomRows/ImageRow/ImageRow.swift
@@ -91,12 +91,12 @@ open class _ImageRow<Cell: CellType>: SelectorRow<Cell, ImagePickerController> w
             if let controller = presentationMode.makeController(){
                 controller.row = self
                 controller.sourceType = sourceType
-                onPresentCallback?(cell.formViewController()!, controller)
-                presentationMode.present(controller, row: self, presentingController: cell.formViewController()!)
+                onPresentCallback?(cell.viewController()!, controller)
+                presentationMode.present(controller, row: self, presentingController: cell.viewController()!)
             }
             else{
                 _sourceType = sourceType
-                presentationMode.present(nil, row: self, presentingController: cell.formViewController()!)
+                presentationMode.present(nil, row: self, presentingController: cell.viewController()!)
             }
         }
     }
@@ -128,7 +128,7 @@ open class _ImageRow<Cell: CellType>: SelectorRow<Cell, ImagePickerController> w
         
         // now that we know the number of actions aren't empty
         let sourceActionSheet = UIAlertController(title: nil, message: selectorTitle, preferredStyle: .actionSheet)
-        guard let tableView = cell.formViewController()?.tableView  else { fatalError() }
+        guard let tableView = cell.parentTableView()  else { fatalError() }
         if let popView = sourceActionSheet.popoverPresentationController {
             popView.sourceView = tableView
             popView.sourceRect = tableView.convert(cell.accessoryView?.frame ?? cell.contentView.frame, from: cell)
@@ -151,7 +151,7 @@ open class _ImageRow<Cell: CellType>: SelectorRow<Cell, ImagePickerController> w
             let cancelOption = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler:nil)
             sourceActionSheet.addAction(cancelOption)
             
-            if let presentingViewController = cell.formViewController() {
+            if let presentingViewController = cell.viewController() {
                 presentingViewController.present(sourceActionSheet, animated: true)
             }
         }

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -48,7 +48,12 @@ class HomeViewController : FormViewController {
                         $0.title = $0.tag
                         $0.presentationMode = .segueName(segueName: "RowsExampleViewControllerSegue", onDismiss: nil)
                     }
-            
+
+            <<< ButtonRow("PD TEST") {
+                $0.title = $0.tag
+                $0.presentationMode = .segueName(segueName: "PDTESTExampleViewControllerSegue", onDismiss: nil)
+            }
+
                 <<< ButtonRow("Native iOS Event Form") { row in
                         row.title = row.tag
                         row.presentationMode = .segueName(segueName: "NativeEventsFormNavigationControllerSegue", onDismiss:{  vc in vc.dismiss(animated: true) })
@@ -119,6 +124,53 @@ class HomeViewController : FormViewController {
 
 typealias Emoji = String
 let 👦🏼 = "👦🏼", 🍐 = "🍐", 💁🏻 = "💁🏻", 🐗 = "🐗", 🐼 = "🐼", 🐻 = "🐻", 🐖 = "🐖", 🐡 = "🐡"
+
+
+class PDTESTViewModel: PDFormViewModel {
+
+    override init() {
+        super.init()
+
+        // setup sections and rows using eureka
+
+        let section = Section()
+
+        section
+
+            <<< LabelRow().cellUpdate { cell, row in
+                cell.textLabel?.text = "Hello World"
+                }.onCellSelection() { row in
+                    print("I'm working")
+                }
+            <<< ActionSheetRow<String>() {
+                $0.title = "ActionSheetRow"
+                $0.selectorTitle = "Your favourite player?"
+                $0.options = ["Diego Forlán", "Edinson Cavani", "Diego Lugano", "Luis Suarez"]
+                $0.value = "Luis Suarez"
+            }
+
+        tableContent.append(section)
+    }
+
+}
+
+class PDTESTExampleViewController: UIViewController {
+
+    var formViewController: PDFormViewController?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let topOffset       : CGFloat = 64
+        let bottomOffset    : CGFloat = 0
+        let contentInset    = UIEdgeInsetsMake(topOffset, 0.0, bottomOffset, 0.0)
+        formViewController = configureFormViewController(insets: contentInset)
+        formViewController!.viewModel = PDTESTViewModel()
+
+        formViewController!.tableView?.reloadData()
+    }
+
+}
 
 //Mark: RowsExampleViewController
 

--- a/Example/PDFormViewModel.swift
+++ b/Example/PDFormViewModel.swift
@@ -1,0 +1,342 @@
+//
+// Created by pual on 07.12.16.
+// Copyright (c) 2016 Jommi. All rights reserved.
+//
+
+import Foundation
+import Eureka
+// import CocoaLumberjackSwift
+
+open class PDTableViewController: UIViewController {
+
+    public var tableViewContentInsets: UIEdgeInsets = UIEdgeInsets.zero
+
+    public var tableView: UITableView?
+
+    open override func loadView() {
+        super.loadView()
+        let _tableView = UITableView(frame: CGRect.zero, style: UITableViewStyle.plain)
+        _tableView.separatorStyle       = .none
+        view.addSubview(_tableView)
+        _tableView.frame = view.bounds
+//        _tableView.snp.makeConstraints { make in
+//            make.edges.equalToSuperview()
+//        }
+        _tableView.setContentOffset(CGPoint(x: 0,y: -tableViewContentInsets.top), animated: false)
+
+        tableView = _tableView
+    }
+
+    var didSetupInsetsOnce: Bool = false
+
+    open override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        tableView?.contentInset          = tableViewContentInsets
+        tableView?.scrollIndicatorInsets = tableViewContentInsets
+
+        if (!didSetupInsetsOnce) {
+            tableView?.setContentOffset(CGPoint(x: 0,y: -tableViewContentInsets.top), animated: false)
+            didSetupInsetsOnce = true
+        }
+
+    }
+
+    open override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if let selectedIndexPath = tableView?.indexPathForSelectedRow {
+            tableView?.deselectRow(at: selectedIndexPath, animated: true)
+        }
+        
+    }
+    
+}
+
+extension UIViewController {
+
+    func configureFormViewController(insets: UIEdgeInsets = UIEdgeInsets.zero) -> PDFormViewController {
+
+        let childViewController = PDFormViewController()
+        childViewController.tableViewContentInsets = insets
+
+        addChildViewController(childViewController)
+        childViewController.didMove(toParentViewController: self)
+        childViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        childViewController.view.frame = view.bounds
+        view.addSubview(childViewController.view)
+//        childViewController.view.snp.makeConstraints { make in
+//            make.edges.equalToSuperview()
+//        }
+        return childViewController
+
+    }
+
+}
+
+open class PDFormViewController: PDTableViewController {
+    var viewModel: PDFormViewModel? {
+        didSet {
+            viewModel?.linkedViewController = self
+            tableView?.dataSource   = viewModel
+            tableView?.delegate     = viewModel
+        }
+    }
+}
+
+open class PDFormViewModel : NSObject {
+
+    weak var linkedViewController: PDFormViewController?
+
+    private lazy var _tableContent : Form = { [weak self] in
+        let form = Form()
+        form.delegate = self
+        return form
+        }()
+
+    public var tableContent : Form {
+        get { return _tableContent }
+        set {
+            guard tableContent !== newValue else { return }
+            _tableContent.delegate = nil
+            tableView?.endEditing(false)
+            _tableContent = newValue
+            _tableContent.delegate = self
+        }
+    }
+
+}
+
+extension PDFormViewModel : UITableViewDataSource {
+
+    //MARK: UITableViewDataSource
+
+    open func numberOfSections(in tableView: UITableView) -> Int {
+        return tableContent.count
+    }
+
+    open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableContent[section].count
+    }
+
+    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        tableContent[indexPath.section][indexPath.row].updateCell()
+        return tableContent[indexPath.section][indexPath.row].baseCell
+    }
+
+    open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return tableContent[section].header?.title
+    }
+
+    open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return tableContent[section].footer?.title
+    }
+
+}
+
+extension PDFormViewModel : UITableViewDelegate {
+
+    open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        //        guard tableView == self.tableView else { DDLogError(""); return }
+        let row = tableContent[indexPath.section][indexPath.row]
+        // row.baseCell.cellBecomeFirstResponder() may be cause InlineRow collapsed then section count will be changed. Use orignal indexPath will out of  section's bounds.
+        if !row.baseCell.cellCanBecomeFirstResponder() || !row.baseCell.cellBecomeFirstResponder() {
+            self.tableView?.endEditing(true)
+        }
+        row.didSelect()
+    }
+
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        //        guard tableView == self.tableView else { DDLogError(""); return tableView.rowHeight }
+        let row = tableContent[indexPath.section][indexPath.row]
+        return row.baseCell.height?() ?? tableView.rowHeight
+    }
+
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        //        guard tableView == self.tableView else { DDLogError(""); return tableView.rowHeight }
+        let row = tableContent[indexPath.section][indexPath.row]
+        return row.baseCell.height?() ?? tableView.estimatedRowHeight
+    }
+
+    open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return tableContent[section].header?.viewForSection(tableContent[section], type: .header)
+    }
+
+    open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return tableContent[section].footer?.viewForSection(tableContent[section], type:.footer)
+    }
+
+    open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if let height = tableContent[section].header?.height {
+            return height()
+        }
+        guard let view = tableContent[section].header?.viewForSection(tableContent[section], type: .header) else{
+            return UITableViewAutomaticDimension
+        }
+        guard view.bounds.height != 0 else {
+            return UITableViewAutomaticDimension
+        }
+        return view.bounds.height
+    }
+
+    open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if let height = tableContent[section].footer?.height {
+            return height()
+        }
+        guard let view = tableContent[section].footer?.viewForSection(tableContent[section], type: .footer) else{
+            return UITableViewAutomaticDimension
+        }
+        guard view.bounds.height != 0 else {
+            return UITableViewAutomaticDimension
+        }
+        return view.bounds.height
+    }
+
+}
+
+
+extension PDFormViewModel: FormDelegate {
+
+    //MARK: FormDelegate
+
+    open func sectionsHaveBeenAdded(_ sections: [Section], at indexes: IndexSet){
+        tableView?.beginUpdates()
+        tableView?.insertSections(indexes, with: insertAnimation(forSections: sections))
+        tableView?.endUpdates()
+    }
+
+    open func sectionsHaveBeenRemoved(_ sections: [Section], at indexes: IndexSet){
+        tableView?.beginUpdates()
+        tableView?.deleteSections(indexes, with: deleteAnimation(forSections: sections))
+        tableView?.endUpdates()
+    }
+
+    open func sectionsHaveBeenReplaced(oldSections:[Section], newSections: [Section], at indexes: IndexSet){
+        tableView?.beginUpdates()
+        tableView?.reloadSections(indexes, with: reloadAnimation(oldSections: oldSections, newSections: newSections))
+        tableView?.endUpdates()
+    }
+
+
+    open func rowsHaveBeenAdded(_ rows: [BaseRow], at indexes: [IndexPath]) {
+        tableView?.beginUpdates()
+        tableView?.insertRows(at: indexes, with: insertAnimation(forRows: rows))
+        tableView?.endUpdates()
+    }
+
+    open func rowsHaveBeenRemoved(_ rows: [BaseRow], at indexes: [IndexPath]) {
+        tableView?.beginUpdates()
+        tableView?.deleteRows(at: indexes, with: deleteAnimation(forRows: rows))
+        tableView?.endUpdates()
+    }
+
+    open func rowsHaveBeenReplaced(oldRows:[BaseRow], newRows: [BaseRow], at indexes: [IndexPath]){
+        tableView?.beginUpdates()
+        tableView?.reloadRows(at: indexes, with: reloadAnimation(oldRows: oldRows, newRows: newRows))
+        tableView?.endUpdates()
+    }
+
+    open func valueHasBeenChanged(for: BaseRow, oldValue: Any?, newValue: Any?) {
+        print("oldValue: \(oldValue), newValue: \(newValue)")
+    }
+
+}
+
+extension PDFormViewModel : FormViewControllerProtocol {
+
+
+    open func inputAccessoryView(for row: BaseRow) -> UIView? { return nil }
+    open func textInputShouldBeginEditing<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool { return false }
+    open func textInputDidBeginEditing<T>(_ textInput: UITextInput, cell: Cell<T>) { }
+    open func textInputShouldEndEditing<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool { return false }
+    open func textInputDidEndEditing<T>(_ textInput: UITextInput, cell: Cell<T>) { return }
+    open func textInput<T>(_ textInput: UITextInput, shouldChangeCharactersInRange range: NSRange, replacementString string: String, cell: Cell<T>) -> Bool { return false }
+    open func textInputShouldClear<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool { return false }
+    open func textInputShouldReturn<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool { return false }
+
+    //MARK: FormViewControllerProtocol
+
+    public var tableView: UITableView? {
+        let result = linkedViewController?.tableView
+        if result == nil {
+            print("is nil")
+        }
+        return result
+    }
+
+    /**
+     Called when a cell becomes first responder
+     */
+    public final func beginEditing<T:Equatable>(of cell: Cell<T>) {
+        cell.row.isHighlighted = true
+        cell.row.updateCell()
+        //        RowDefaults.onCellHighlightChanged["\(type(of: cell.row!))"]?(cell, cell.row)
+        //        cell.row.callbackOnCellHighlightChanged?()
+        //        guard let _ = tableView, (tableContent.inlineRowHideOptions ?? tableContent.defaultInlineRowHideOptions).contains(.FirstResponderChanges) else { return }
+        //        let row = cell.baseRow
+        //        let inlineRow = row?._inlineRow
+        //        for row in tableContent.allRows.filter({ $0 !== row && $0 !== inlineRow && $0._inlineRow != nil }) {
+        //            if let inlineRow = row as? BaseInlineRowType {
+        //                inlineRow.collapseInlineRow()
+        //            }
+        //        }
+    }
+
+    /**
+     Called when a cell resigns first responder
+     */
+    public final func endEditing<T:Equatable>(of cell: Cell<T>) {
+        print("")
+        cell.row.isHighlighted = false
+        //        cell.row.wasBlurred = true
+        //        RowDefaults.onCellHighlightChanged["\(type(of: self))"]?(cell, cell.row)
+        //        cell.row.callbackOnCellHighlightChanged?()
+        if cell.row.validationOptions.contains(.validatesOnBlur) ||  cell.row.validationOptions.contains(.validatesOnChangeAfterBlurred) {
+            cell.row.validate()
+        }
+        cell.row.updateCell()
+    }
+
+    /**
+     Returns the animation for the insertion of the given rows.
+     */
+    open func insertAnimation(forRows rows: [BaseRow]) -> UITableViewRowAnimation {
+        return .fade
+    }
+
+    /**
+     Returns the animation for the deletion of the given rows.
+     */
+    open func deleteAnimation(forRows rows: [BaseRow]) -> UITableViewRowAnimation {
+        return .fade
+    }
+
+    /**
+     Returns the animation for the reloading of the given rows.
+     */
+    open func reloadAnimation(oldRows: [BaseRow], newRows: [BaseRow]) -> UITableViewRowAnimation {
+        return .automatic
+    }
+
+    /**
+     Returns the animation for the insertion of the given sections.
+     */
+    open func insertAnimation(forSections sections: [Section]) -> UITableViewRowAnimation {
+        return .automatic
+    }
+
+    /**
+     Returns the animation for the deletion of the given sections.
+     */
+    open func deleteAnimation(forSections sections: [Section]) -> UITableViewRowAnimation {
+        return .automatic
+    }
+    
+    /**
+     Returns the animation for the reloading of the given sections.
+     */
+    open func reloadAnimation(oldSections: [Section], newSections: [Section]) -> UITableViewRowAnimation {
+        return .automatic
+    }
+    
+}

--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -243,23 +243,22 @@ extension BaseRow {
 
 extension BaseRow: Equatable, Hidable, Disableable {}
 
-
 extension BaseRow {
     
     public func reload(with rowAnimation: UITableViewRowAnimation = .none) {
-        guard let tableView = baseCell?.formViewController()?.tableView ?? (section?.form?.delegate as? FormViewController)?.tableView, let indexPath = indexPath else { return }
+        guard let tableView = baseCell?.parentTableView(), let indexPath = indexPath else { return }
         tableView.reloadRows(at: [indexPath], with: rowAnimation)
     }
     
     public func deselect(animated: Bool = true) {
         guard let indexPath = indexPath,
-            let tableView = baseCell?.formViewController()?.tableView ?? (section?.form?.delegate as? FormViewController)?.tableView  else { return }
+            let tableView = baseCell?.parentTableView()  else { return }
         tableView.deselectRow(at: indexPath, animated: animated)
     }
     
     public func select(animated: Bool = false) {
         guard let indexPath = indexPath,
-            let tableView = baseCell?.formViewController()?.tableView ?? (section?.form?.delegate as? FormViewController)?.tableView  else { return }
+            let tableView = baseCell?.parentTableView()  else { return }
         tableView.selectRow(at: indexPath, animated: animated, scrollPosition: .none)
     }
 }

--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -44,17 +44,24 @@ open class BaseCell : UITableViewCell, BaseCellType {
 
     /**
      Function that returns the FormViewController this cell belongs to.
+     Will be set by the controller instantiating the cell.
      */
-    public func formViewController() -> FormViewController? {
+    public var formViewDelegate: FormViewControllerProtocol?
+
+    /**
+     Function that returns the ViewController this cell belongs to.
+     */
+    public func viewController() -> UIViewController? {
         var responder : AnyObject? = self
         while responder != nil {
-            if responder! is FormViewController {
-                return responder as? FormViewController
+            if responder! is UIViewController {
+                return responder as? UIViewController
             }
             responder = responder?.next
         }
         return nil
     }
+
 
     open func setup(){}
     open func update() {}
@@ -85,6 +92,24 @@ open class BaseCell : UITableViewCell, BaseCellType {
     }
 }
 
+extension BaseCell {
+
+    /**
+     Will iterate through the superviews to find the tableView the cell belongs to.
+     */
+    public func parentTableView() -> UITableView? {
+        var view: UIView? = self
+        while (view != nil) {
+            if view?.isKind(of: UITableView.self) ?? false {
+                return view as? UITableView
+            }
+            view = view?.superview ?? nil
+        }
+        return nil
+    }
+
+}
+
 /// Generic class that represents the Eureka cells.
 open class Cell<T: Equatable> : BaseCell, TypedCellType {
 
@@ -95,7 +120,7 @@ open class Cell<T: Equatable> : BaseCell, TypedCellType {
 
     /// Returns the navigationAccessoryView if it is defined or calls super if not.
     override open var inputAccessoryView: UIView? {
-        if let v = formViewController()?.inputAccessoryView(for: row){
+        if let v = formViewDelegate?.inputAccessoryView(for: row){
             return v
         }
         return super.inputAccessoryView
@@ -139,7 +164,7 @@ open class Cell<T: Equatable> : BaseCell, TypedCellType {
     open override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result {
-            formViewController()?.beginEditing(of: self)
+            formViewDelegate?.beginEditing(of: self)
         }
         return result
     }
@@ -147,7 +172,7 @@ open class Cell<T: Equatable> : BaseCell, TypedCellType {
     open override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
         if result {
-            formViewController()?.endEditing(of: self)
+            formViewDelegate?.endEditing(of: self)
         }
         return result
     }

--- a/Source/Core/CellType.swift
+++ b/Source/Core/CellType.swift
@@ -63,11 +63,12 @@ public protocol BaseCellType : class {
      Method called when the cell resigns first responder
      */
     func cellResignFirstResponder() -> Bool
-    
+
     /**
      A reference to the controller in which the cell is displayed.
      */
-    func formViewController () -> FormViewController?
+    var formViewDelegate: FormViewControllerProtocol? { get set }
+
 }
 
 

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -342,7 +342,7 @@ public protocol FormViewControllerProtocol {
     func deleteAnimation(forSections sections : [Section]) -> UITableViewRowAnimation
     func reloadAnimation(oldSections: [Section], newSections:[Section]) -> UITableViewRowAnimation
 
-    // UITestField delegate methods
+    // UITextField delegate methods
     func inputAccessoryView(for row: BaseRow) -> UIView?
     func textInputShouldBeginEditing<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool
     func textInputDidBeginEditing<T>(_ textInput: UITextInput, cell: Cell<T>)

--- a/Source/Core/InlineRowType.swift
+++ b/Source/Core/InlineRowType.swift
@@ -87,7 +87,7 @@ extension InlineRowType where Self: BaseRow, Self.InlineRow : BaseRow, Self.Cell
             if let indexPath = indexPath {
                 section.insert(inline, at: indexPath.row + 1)
                 _inlineRow = inline
-                cell.formViewController()?.makeRowVisible(inline)
+                cell.formViewDelegate?.makeRowVisible(inline)
             }
         }
     }

--- a/Source/Core/PresenterRowType.swift
+++ b/Source/Core/PresenterRowType.swift
@@ -37,7 +37,7 @@ public protocol PresenterRowType: TypedRowType {
     var presentationMode: PresentationMode<ProviderType>? { get set }
     
     /// Will be called before the presentation occurs.
-    var onPresentCallback: ((FormViewController, ProviderType)->())? { get set }
+    var onPresentCallback: ((UIViewController, ProviderType)->())? { get set }
 }
 
 extension PresenterRowType {
@@ -49,7 +49,7 @@ extension PresenterRowType {
      
      - returns: this row
      */
-    public func onPresent(_ callback: ((FormViewController, ProviderType)->())?) -> Self {
+    public func onPresent(_ callback: ((UIViewController, ProviderType)->())?) -> Self {
         onPresentCallback = callback
         return self
     }

--- a/Source/Rows/AlertRow.swift
+++ b/Source/Rows/AlertRow.swift
@@ -26,7 +26,7 @@ import Foundation
 
 open class _AlertRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
     
-    open var onPresentCallback : ((FormViewController, SelectorAlertController<Cell.Value>)->())?
+    open var onPresentCallback : ((UIViewController, SelectorAlertController<Cell.Value>)->())?
     lazy open var presentationMode: PresentationMode<SelectorAlertController<Cell.Value>>? = {
         return .presentModally(controllerProvider: ControllerProvider.callback { [weak self] in
             let vc = SelectorAlertController<Cell.Value>(title: self?.selectorTitle, message: nil, preferredStyle: .alert)
@@ -34,7 +34,7 @@ open class _AlertRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType where C
             return vc
             }, onDismiss: { [weak self] in
                 $0.dismiss(animated: true)
-                self?.cell?.formViewController()?.tableView?.reloadData()
+                self?.cell?.parentTableView()?.reloadData()
             }
         )
     }()
@@ -48,11 +48,11 @@ open class _AlertRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType where C
         if let presentationMode = presentationMode, !isDisabled  {
             if let controller = presentationMode.makeController(){
                 controller.row = self
-                onPresentCallback?(cell.formViewController()!, controller)
-                presentationMode.present(controller, row: self, presentingController: cell.formViewController()!)
+                onPresentCallback?(cell.viewController()!, controller)
+                presentationMode.present(controller, row: self, presentingController: cell.viewController()!)
             }
             else{
-                presentationMode.present(nil, row: self, presentingController: cell.formViewController()!)
+                presentationMode.present(nil, row: self, presentingController: cell.viewController()!)
             }
         }
     }

--- a/Source/Rows/ButtonRow.swift
+++ b/Source/Rows/ButtonRow.swift
@@ -73,10 +73,10 @@ open class _ButtonRowOf<T: Equatable> : Row<ButtonCellOf<T>> {
         if !isDisabled {
             if let presentationMode = presentationMode {
                 if let controller = presentationMode.makeController(){
-                    presentationMode.present(controller, row: self, presentingController: self.cell.formViewController()!)
+                    presentationMode.present(controller, row: self, presentingController: self.cell.viewController()!)
                 }
                 else{
-                    presentationMode.present(nil, row: self, presentingController: self.cell.formViewController()!)
+                    presentationMode.present(nil, row: self, presentingController: self.cell.viewController()!)
                 }
             }
         }

--- a/Source/Rows/ButtonRowWithPresent.swift
+++ b/Source/Rows/ButtonRowWithPresent.swift
@@ -27,7 +27,7 @@ import Foundation
 open class _ButtonRowWithPresent<VCType: TypedRowControllerType>: Row<ButtonCellOf<VCType.RowValue>>, PresenterRowType where VCType: UIViewController {
     
     open var presentationMode: PresentationMode<VCType>?
-    open var onPresentCallback : ((FormViewController, VCType)->())?
+    open var onPresentCallback : ((UIViewController, VCType)->())?
     
     required public init(tag: String?) {
         super.init(tag: tag)
@@ -56,11 +56,11 @@ open class _ButtonRowWithPresent<VCType: TypedRowControllerType>: Row<ButtonCell
         if let presentationMode = presentationMode, !isDisabled {
             if let controller = presentationMode.makeController(){
                 controller.row = self
-                onPresentCallback?(cell.formViewController()!, controller)
-                presentationMode.present(controller, row: self, presentingController: cell.formViewController()!)
+                onPresentCallback?(cell.viewController()!, controller)
+                presentationMode.present(controller, row: self, presentingController: cell.viewController()!)
             }
             else{
-                presentationMode.present(nil, row: self, presentingController: cell.formViewController()!)
+                presentationMode.present(nil, row: self, presentingController: cell.viewController()!)
             }
         }
     }
@@ -74,7 +74,7 @@ open class _ButtonRowWithPresent<VCType: TypedRowControllerType>: Row<ButtonCell
             rowVC.onDismissCallback = callback
         }
         rowVC.row = self
-        onPresentCallback?(cell.formViewController()!, rowVC)
+        onPresentCallback?(cell.viewController()!, rowVC)
     }
     
 }

--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -319,8 +319,8 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
     //MARK: TextFieldDelegate
     
     open func textFieldDidBeginEditing(_ textField: UITextField) {
-        formViewController()?.beginEditing(of: self)
-        formViewController()?.textInputDidBeginEditing(textField, cell: self)
+        formViewDelegate?.beginEditing(of: self)
+        formViewDelegate?.textInputDidBeginEditing(textField, cell: self)
         if let fieldRowConformance = row as? FormatterConformance, let _ = fieldRowConformance.formatter, fieldRowConformance.useFormatterOnDidBeginEditing ?? fieldRowConformance.useFormatterDuringInput {
             textField.text = displayValue(useFormatter: true)
         } else {
@@ -329,30 +329,30 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
     }
     
     open func textFieldDidEndEditing(_ textField: UITextField) {
-        formViewController()?.endEditing(of: self)
-        formViewController()?.textInputDidEndEditing(textField, cell: self)
+        formViewDelegate?.endEditing(of: self)
+        formViewDelegate?.textInputDidEndEditing(textField, cell: self)
         textFieldDidChange(textField)
         textField.text = displayValue(useFormatter: (row as? FormatterConformance)?.formatter != nil)
     }
     
     open func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        return formViewController()?.textInputShouldReturn(textField, cell: self) ?? true
+        return formViewDelegate?.textInputShouldReturn(textField, cell: self) ?? true
     }
     
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        return formViewController()?.textInput(textField, shouldChangeCharactersInRange:range, replacementString:string, cell: self) ?? true
+        return formViewDelegate?.textInput(textField, shouldChangeCharactersInRange:range, replacementString:string, cell: self) ?? true
     }
     
     open func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-        return formViewController()?.textInputShouldBeginEditing(textField, cell: self) ?? true
+        return formViewDelegate?.textInputShouldBeginEditing(textField, cell: self) ?? true
     }
     
     open func textFieldShouldClear(_ textField: UITextField) -> Bool {
-        return formViewController()?.textInputShouldClear(textField, cell: self) ?? true
+        return formViewDelegate?.textInputShouldClear(textField, cell: self) ?? true
     }
     
     open func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        return formViewController()?.textInputShouldEndEditing(textField, cell: self) ?? true
+        return formViewDelegate?.textInputShouldEndEditing(textField, cell: self) ?? true
     }
     
     

--- a/Source/Rows/Common/GenericMultipleSelectorRow.swift
+++ b/Source/Rows/Common/GenericMultipleSelectorRow.swift
@@ -33,7 +33,7 @@ open class GenericMultipleSelectorRow<T: Hashable, Cell: CellType, VCType: Typed
     open var presentationMode: PresentationMode<VCType>?
     
     /// Will be called before the presentation occurs.
-    open var onPresentCallback : ((FormViewController, VCType)->())?
+    open var onPresentCallback : ((UIViewController, VCType)->())?
     
     /// Title to be displayed for the options
     open var selectorTitle: String?
@@ -64,11 +64,11 @@ open class GenericMultipleSelectorRow<T: Hashable, Cell: CellType, VCType: Typed
         if let controller = presentationMode.makeController(){
             controller.row = self
             controller.title = selectorTitle ?? controller.title
-            onPresentCallback?(cell.formViewController()!, controller)
-            presentationMode.present(controller, row: self, presentingController: self.cell.formViewController()!)
+            onPresentCallback?(cell.viewController()!, controller)
+            presentationMode.present(controller, row: self, presentingController: self.cell.viewController()!)
         }
         else{
-            presentationMode.present(nil, row: self, presentingController: self.cell.formViewController()!)
+            presentationMode.present(nil, row: self, presentingController: self.cell.viewController()!)
         }
     }
     
@@ -80,7 +80,7 @@ open class GenericMultipleSelectorRow<T: Hashable, Cell: CellType, VCType: Typed
         guard let rowVC = segue.destination as? VCType else { return }
         rowVC.title = selectorTitle ?? rowVC.title
         rowVC.onDismissCallback = presentationMode?.onDismissCallback ?? rowVC.onDismissCallback
-        onPresentCallback?(cell.formViewController()!, rowVC)
+        onPresentCallback?(cell.viewController()!, rowVC)
         rowVC.row = self
     }
 }

--- a/Source/Rows/Common/SelectorRow.swift
+++ b/Source/Rows/Common/SelectorRow.swift
@@ -49,7 +49,7 @@ open class SelectorRow<Cell: CellType, VCType: TypedRowControllerType>: OptionsR
     open var presentationMode: PresentationMode<VCType>?
     
     /// Will be called before the presentation occurs.
-    open var onPresentCallback : ((FormViewController, VCType)->())?
+    open var onPresentCallback : ((UIViewController, VCType)->())?
     
     required public init(tag: String?) {
         super.init(tag: tag)
@@ -64,11 +64,11 @@ open class SelectorRow<Cell: CellType, VCType: TypedRowControllerType>: OptionsR
         if let controller = presentationMode.makeController(){
             controller.row = self
             controller.title = selectorTitle ?? controller.title
-            onPresentCallback?(cell.formViewController()!, controller)
-            presentationMode.present(controller, row: self, presentingController: self.cell.formViewController()!)
+            onPresentCallback?(cell.viewController()!, controller)
+            presentationMode.present(controller, row: self, presentingController: self.cell.viewController()!)
         }
         else{
-            presentationMode.present(nil, row: self, presentingController: self.cell.formViewController()!)
+            presentationMode.present(nil, row: self, presentingController: self.cell.viewController()!)
         }
     }
     
@@ -80,7 +80,7 @@ open class SelectorRow<Cell: CellType, VCType: TypedRowControllerType>: OptionsR
         guard let rowVC = segue.destination as? VCType else { return }
         rowVC.title = selectorTitle ?? rowVC.title
         rowVC.onDismissCallback = presentationMode?.onDismissCallback ?? rowVC.onDismissCallback
-        onPresentCallback?(cell.formViewController()!, rowVC)
+        onPresentCallback?(cell.viewController()!, rowVC)
         rowVC.row = self
     }
 }

--- a/Source/Rows/PopoverSelectorRow.swift
+++ b/Source/Rows/PopoverSelectorRow.swift
@@ -29,7 +29,7 @@ open class _PopoverSelectorRow<Cell: CellType> : SelectorRow<Cell, SelectorViewC
     public required init(tag: String?) {
         super.init(tag: tag)
         onPresentCallback = { [weak self] (_, viewController) -> Void in
-            guard let porpoverController = viewController.popoverPresentationController, let tableView = self?.baseCell.formViewController()?.tableView, let cell = self?.cell else {
+            guard let porpoverController = viewController.popoverPresentationController, let tableView = self?.baseCell.parentTableView(), let cell = self?.cell else {
                 fatalError()
             }
             porpoverController.sourceView = tableView

--- a/Source/Rows/TextAreaRow.swift
+++ b/Source/Rows/TextAreaRow.swift
@@ -149,8 +149,8 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
     
     
     open func textViewDidBeginEditing(_ textView: UITextView) {
-        formViewController()?.beginEditing(of: self)
-        formViewController()?.textInputDidBeginEditing(textView, cell: self)
+        formViewDelegate?.beginEditing(of: self)
+        formViewDelegate?.textInputDidBeginEditing(textView, cell: self)
         if let textAreaConformance = (row as? TextAreaConformance), let _ = textAreaConformance.formatter, textAreaConformance.useFormatterOnDidBeginEditing ?? textAreaConformance.useFormatterDuringInput {
             textView.text = self.displayValue(useFormatter: true)
         }
@@ -160,15 +160,15 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
     }
     
     open func textViewDidEndEditing(_ textView: UITextView) {
-        formViewController()?.endEditing(of: self)
-        formViewController()?.textInputDidEndEditing(textView, cell: self)
+        formViewDelegate?.endEditing(of: self)
+        formViewDelegate?.textInputDidEndEditing(textView, cell: self)
         textViewDidChange(textView)
         textView.text = displayValue(useFormatter: (row as? FormatterConformance)?.formatter != nil)
     }
     
     open func textViewDidChange(_ textView: UITextView) {
         
-        if let textAreaConformance = row as? TextAreaConformance, case .dynamic = textAreaConformance.textAreaHeight, let tableView = formViewController()?.tableView {
+        if let textAreaConformance = row as? TextAreaConformance, case .dynamic = textAreaConformance.textAreaHeight, let tableView = parentTableView() {
             let currentOffset = tableView.contentOffset
             UIView.setAnimationsEnabled(false)
             tableView.beginUpdates()
@@ -208,15 +208,15 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
     }
     
     open func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        return formViewController()?.textInput(textView, shouldChangeCharactersInRange: range, replacementString: text, cell: self) ?? true
+        return formViewDelegate?.textInput(textView, shouldChangeCharactersInRange: range, replacementString: text, cell: self) ?? true
     }
     
     open func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        return formViewController()?.textInputShouldBeginEditing(textView, cell: self) ?? true
+        return formViewDelegate?.textInputShouldBeginEditing(textView, cell: self) ?? true
     }
     
     open func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
-        return formViewController()?.textInputShouldEndEditing(textView, cell: self) ?? true
+        return formViewDelegate?.textInputShouldEndEditing(textView, cell: self) ?? true
     }
     
     open override func updateConstraints(){


### PR DESCRIPTION
In the Project Readme I read

> You could create a form by just setting up the form property by yourself without extending from FormViewController but this method is typically more convenient.

but it didn't work for me. The cause was the dependency on the FormViewController class (or subclass) in the source, now it's fixed.