### PR TITLE
Set RuleRegExp.allowsEmpty

### DIFF
--- a/Source/Validations/RuleRegExp.swift
+++ b/Source/Validations/RuleRegExp.swift
@@ -41,6 +41,7 @@ public class RuleRegExp: RuleType {
     
     public init(regExpr: String, allowsEmpty: Bool = true){
         self.regExpr = regExpr
+        self.allowsEmpty = allowsEmpty
     }
     
     public func isValid(value: String?) -> ValidationError? {


### PR DESCRIPTION
Someone forgot to set `self.allowsEmpty` in the initializer