### PR TITLE
Implement init?(coder: NSCoder) for some cell types

### DIFF
--- a/Source/Rows/ActionSheetRow.swift
+++ b/Source/Rows/ActionSheetRow.swift
@@ -32,7 +32,7 @@ open class AlertSelectorCell<T: Equatable> : Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func update() {

--- a/Source/Rows/ButtonRow.swift
+++ b/Source/Rows/ButtonRow.swift
@@ -33,7 +33,7 @@ open class ButtonCellOf<T: Equatable>: Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func update() {

--- a/Source/Rows/CheckRow.swift
+++ b/Source/Rows/CheckRow.swift
@@ -33,7 +33,7 @@ public final class CheckCell : Cell<Bool>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func update() {

--- a/Source/Rows/Common/DateInlineFieldRow.swift
+++ b/Source/Rows/Common/DateInlineFieldRow.swift
@@ -32,7 +32,7 @@ open class DateInlineCell : Cell<Date>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func setup() {

--- a/Source/Rows/Common/SelectorRow.swift
+++ b/Source/Rows/Common/SelectorRow.swift
@@ -31,7 +31,7 @@ open class PushSelectorCell<T: Equatable> : Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func update() {

--- a/Source/Rows/LabelRow.swift
+++ b/Source/Rows/LabelRow.swift
@@ -33,7 +33,7 @@ open class LabelCellOf<T: Equatable>: Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func setup() {

--- a/Source/Rows/PickerInlineRow.swift
+++ b/Source/Rows/PickerInlineRow.swift
@@ -31,7 +31,7 @@ open class PickerInlineCell<T: Equatable> : Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func setup() {

--- a/Source/Rows/SelectableRows/ListCheckRow.swift
+++ b/Source/Rows/SelectableRows/ListCheckRow.swift
@@ -31,7 +31,7 @@ open class ListCheckCell<T: Equatable> : Cell<T>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func update() {

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -35,7 +35,7 @@ open class SwitchCell : Cell<Bool>, CellType {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open var switchControl: UISwitch? {


### PR DESCRIPTION
**The problem**
I've created a custom cell by:
- implementing a cell class that inherits `ButtonCellOf`
- implementing a row class that inherits from `Eureka._ButtonRowOf`

The row class instantiates `CellProvider` and passes a NIB name.

Now, this used to work fine in Eureka 1.7. However, after I updated to the latest Swift 3 master, the following problem has arisen:
- my custom cell implementation wouldn't compile unless `init?(coder: NSCoder)` was implemented
- when I've implemented it by calling `init?(coder: NSCoder)` on `super`, the app has started to crash.

**The solution**
I think that the problem exists because `init?(coder: NSCoder)` in `ButtonCellOf` calls `fatalError` instead of calling `init` on `super`. I suspect that it has been introduced while migrating to Swift 3. This pull request changes that behaviour. 

I've applied the same change to other cell classes that have trivial initialisers.