### PR TITLE
Removed fatalError from init(coder:) for selector view controllers

### DIFF
--- a/Source/Rows/Controllers/MultipleSelectorViewController.swift
+++ b/Source/Rows/Controllers/MultipleSelectorViewController.swift
@@ -47,7 +47,7 @@ open class _MultipleSelectorViewController<T:Hashable, Row: SelectableRowType> :
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func viewDidLoad() {

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -40,7 +40,7 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
     open override func viewDidLoad() {
@@ -80,7 +80,7 @@ open class SelectorViewController<T:Equatable> : _SelectorViewController<ListChe
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
 


### PR DESCRIPTION
Use case scenario: user implements custom selector controller as subclass of `SelectorViewController` for `PushRow` and wishes to instantiate it from a storyboard with a segue transition or a xib. But because of `fatalError` in `init(coder:)` for `SelectorViewController` it is not possible. Segue presentation mode will lead to crash, what was not happening in 1.7.0 release.

I can understand the reasoning for not calling `fatalError` for rows as they are designed to be instantiated from code, but for view controller I don't see reason not to allow to instantiate them from storyboards or xibs. `FormViewController` does not follow that behavior. If there are strong reason for not allowing that that should be stated in the docs and probably segue presentation style should be deprecated for `PushRow` as it is not usable in that case.