### PR TITLE
Always call onSelectSelectableRow, added properties to control selector vc dismissal

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -665,6 +665,7 @@ class NativeEventFormViewController : FormViewController {
                     $0.value = .Never
                 }.onPresent({ (_, vc) in
                     vc.enableDeselection = false
+                    vc.dismissOnSelection = false
                 })
         
         form +++

--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -91,21 +91,20 @@ extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIt
                     switch s.selectionType {
                     case .multipleSelection:
                         row.value = row.value == nil ? row.selectableValue : nil
-                        row.updateCell()
-                        s.onSelectSelectableRow?(cell, row)
-                    case .singleSelection(let enableDeselection):
+                    case let .singleSelection(enableDeselection):
                         s.filter { $0.baseValue != nil && $0 != row }.forEach {
                             $0.baseValue = nil
                             $0.updateCell()
                         }
                         // Check if row is not already selected
-                        if enableDeselection || row.value == nil {
-                            row.value = row.value == nil ? row.selectableValue : nil
-                            row.updateCell()
-                            s.onSelectSelectableRow?(cell, row)
+                        if row.value == nil {
+                            row.value = row.selectableValue
+                        } else if enableDeselection {
+                            row.value = nil
                         }
                     }
-                    
+                    row.updateCell()
+                    s.onSelectSelectableRow?(cell, row)
                 }
             }
         }

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -29,6 +29,8 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
     /// The row that pushed or presented this controller
     public var row: RowOf<Row.Cell.Value>!
     public var enableDeselection = true
+    public var dismissOnSelection = true
+    public var dismissOnChange = true
     
     /// A closure to be called when the controller disappears.
     public var onDismissCallback : ((UIViewController) -> ())?
@@ -50,8 +52,11 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
         form +++ SelectableSection<Row>(row.title ?? "", selectionType: .singleSelection(enableDeselection: enableDeselection)) { [weak self] section in
             if let sec = section as? SelectableSection<Row> {
                 sec.onSelectSelectableRow = { _, row in
+                    let changed = self?.row.value != row.value
                     self?.row.value = row.value
-                    self?.onDismissCallback?(self!)
+                    if self?.dismissOnSelection == true || (changed && self?.dismissOnChange == true) {
+                        self?.onDismissCallback?(self!)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR reverts some of the changes made in #551 and adds two new properties for better control of dismissing `SelectorViewController`. Please see [this](https://github.com/xmartlabs/Eureka/pull/551#issuecomment-262821225) and [this](https://github.com/xmartlabs/Eureka/issues/261#issuecomment-274661489) comments for some reasoning.