### PR TITLE
Reload the tableView even if it is not added to a window

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -425,7 +425,7 @@ open class FormViewController : UIViewController, FormViewControllerProtocol {
             tableView?.endEditing(false)
             _form = newValue
             _form.delegate = self
-            if isViewLoaded && tableView?.window != nil {
+            if isViewLoaded {
                 tableView?.reloadData()
             }
         }


### PR DESCRIPTION
This allows us to change the form of a view controller which is not being displayed at the moment but will be displayed. Sometimes this would throw an UITableView Inconsistency exception.

There seem to be no negative side effects.