### PR TITLE
adds 'cell.row.wasChanged' to check for cell validation

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -576,7 +576,7 @@ open class FormViewController : UIViewController, FormViewControllerProtocol {
         cell.row.wasBlurred = true
         RowDefaults.onCellHighlightChanged["\(type(of: self))"]?(cell, cell.row)
         cell.row.callbackOnCellHighlightChanged?()
-        if cell.row.validationOptions.contains(.validatesOnBlur) ||  cell.row.validationOptions.contains(.validatesOnChangeAfterBlurred) {
+        if cell.row.validationOptions.contains(.validatesOnBlur) || (cell.row.wasChanged && cell.row.validationOptions.contains(.validatesOnChangeAfterBlurred)) {
             cell.row.validate()
         }
         cell.row.updateCell()


### PR DESCRIPTION
Fixes issue: https://github.com/xmartlabs/Eureka/issues/886