### PR TITLE
Removing the forced navigationAccessoryView.tintColor set

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -460,7 +460,6 @@ open class FormViewController : UIViewController, FormViewControllerProtocol {
     open override func viewDidLoad() {
         super.viewDidLoad()
         navigationAccessoryView = NavigationAccessoryView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0))
-        navigationAccessoryView.tintColor = view.tintColor
         navigationAccessoryView.autoresizingMask = .flexibleWidth
         
         if tableView == nil {


### PR DESCRIPTION
Removing the forced navigationAccessoryView.tintColor set to be able to use with the Appearance Proxy.
NavigationAccessoryView.appearance().tintColor = 
NavigationAccessoryView.appearance().barTintColor = UIColor(...)