### PR TITLE
Allow configuration of custom NavigationAccessoryView

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Made with ❤️ by [XMARTLABS](http://xmartlabs.com). This is the re-creation o
   + [Dynamically hide and show rows (or sections)]
   + [List sections]
   + [Validations]
+  + [Customize keyboard toolbar]
 * [Custom rows]
   + [Basic custom rows]
   + [Custom inline rows]
@@ -514,6 +515,88 @@ If you want to validate the entire form (all the rows) you can manually invoke F
 #### How to get validation errors
 
 Each row has the `validationErrors` property that can be used to retrieve all validation errors. This property just holds the validation error list of the latest row validation execution, which means it doesn't evaluate the validation rules of the row.
+
+### Customize keyboard toolbar
+
+#### Set a new toolbar
+
+To set a new keyboard toolbar, set the `inputAccessoryView` in the row init.
+
+```swift
+<<< TextRow() {
+    $0.title = "Title"
+    $0.placeholder = "title"
+
+    //create and set the toolbar
+    let toolbar = UIToolbar(frame: $0.cell.frame)
+    let flexibleSpace = UIBarButtonItem(
+        barButtonSystemItem: .flexibleSpace,
+        target: nil,
+        action: nil
+    )
+    let awesomeButton = UIBarButtonItem(
+        title: "Awesome button",
+        style: .plain,
+        target: nil,
+        action: nil
+    )
+    
+    toolbar.setItems(
+        [
+            flexibleSpace,
+            awesomeButton,
+            flexibleSpace
+        ],
+        animated: false
+    )
+    
+    $0.cell.textField.inputAccessoryView = toolbar
+}
+```
+
+#### Add buttons to the existing toolbar
+
+To reuse the toolbar provided by `FormViewController`, and add buttons to it but keep the same navigation and done buttons, do the following in `onCellHighlightChanged`:
+
+```swift
+<<< TextRow() {
+    $0.title = "Title"
+    $0.placeholder = "title"
+}
+.onCellHighlightChanged { [weak self] (cell, row) in
+    //init the toolbar from the same toolbar use by FormViewController
+    let toolbar = NavigationAccessoryView(frame: row.cell.frame)
+    
+    //create new button and space
+    let fixedSpace = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+    fixedSpace.width = 22.0
+    let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    let awesomeButton = UIBarButtonItem(
+        title: "Awesome button",
+        style: .plain,
+        target: nil,
+        action: nil
+    )
+
+    //set the buttons to the toolbar. reuse button from the FormViewController and add the new one
+    toolbar.setItems(
+        [
+            toolbar.previousButton, //reuse the previous button
+            fixedSpace,
+            toolbar.nextButton, //reuse the next button
+            flexibleSpace,
+            awesomeButton, //new button
+            flexibleSpace,
+            toolbar.doneButton //reuse the done button
+        ],
+        animated: false
+    )
+    
+    //configure the default behaviour of the toolbar and set it to the textfield
+    row.cell.textField.inputAccessoryView = self?.inputAccessoryView(for: row, withView: toolbar)
+}
+
+```
 
 ## Custom rows
 
@@ -1059,6 +1142,7 @@ It's up to you to decide if you want to use Eureka custom operators or not.
 
 [List sections]: #list-sections
 [Validations]: #validations
+[Customize keyboard toolbar]: #customize-keyboard-toolbar
 
 * [Installation]
 * [FAQ]

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -532,7 +532,8 @@ open class FormViewController : UIViewController, FormViewControllerProtocol {
     /**
      Returns the navigation accessory view if it is enabled. Returns nil otherwise.
      */
-    open func inputAccessoryView(for row: BaseRow) -> UIView? {
+    open func inputAccessoryView(for row: BaseRow, withView _navigationAccessoryView: NavigationAccessoryView? = nil) -> UIView? {
+        guard let navigationAccessoryView = _navigationAccessoryView ?? self.navigationAccessoryView else { return nil }
         let options = navigationOptions ?? Form.defaultNavigationOptions
         guard options.contains(.Enabled) else { return nil }
         guard row.baseCell.cellCanBecomeFirstResponder() else { return nil}


### PR DESCRIPTION
This pull request allows to set the default navigation logic and actions on a custom `NavigationAccessoryView`.
The changes are very small: only add an optional parameter to `inputAccessoryView` to allow a "custom" `NavigationAccessoryView` to be config by this function.
It let me add buttons to the keyboard toolbar and still use the default navigation and done buttons.

Also add examples to the README.