### PR TITLE
Overload <<< operator to append multiple rows

### DIFF
--- a/Source/Core/Operators.swift
+++ b/Source/Core/Operators.swift
@@ -141,6 +141,21 @@ public func <<< (left: BaseRow, right: BaseRow) -> Section {
 }
 
 /**
+ Appends a collection of rows to a section.
+ 
+ - parameter left:  the section
+ - parameter right: the collection of rows to be appended
+ 
+ - returns: the section
+ */
+@discardableResult
+public func <<< <C: Collection>(left: Section, right: C) -> Section where C.Iterator.Element == BaseRow {
+    left.append(contentsOf: right)
+    
+    return left
+}
+
+/**
  Appends a collection of rows to a section
  
  - parameter lhs: the section

--- a/Tests/OperatorsTest.swift
+++ b/Tests/OperatorsTest.swift
@@ -49,6 +49,8 @@ class OperatorsTest: BaseEurekaTests {
         form +++ IntRow("introw2_ctx")
             <<< IntRow("introw3_ctx")
             <<< IntRow("introw4_ctx")
+        form +++ Section()
+            <<< ["A", "B", "C", "D"].map { TextRow($0) }
 
         //      form:
         //          text1
@@ -70,7 +72,7 @@ class OperatorsTest: BaseEurekaTests {
         //          int3
         //          int4
 
-        XCTAssertEqual(form.count, 7)
+        XCTAssertEqual(form.count, 8)
         XCTAssertEqual(form[0].count, 2)
         XCTAssertEqual(form[1].count, 2)
         XCTAssertEqual(form[2].count, 2)
@@ -78,6 +80,7 @@ class OperatorsTest: BaseEurekaTests {
         XCTAssertEqual(form[4].count, 1)
         XCTAssertEqual(form[5].count, 1)
         XCTAssertEqual(form[6].count, 3)
+        XCTAssertEqual(form[7].count, 4)
     }
 
 }


### PR DESCRIPTION
Instead of using the following:
```swift
form +++ SelectableSection<ListCheckRow<String>>("Where do you live", selectionType: .singleSelection(enableDeselection: true))

let continents = ["Africa", "Antarctica", "Asia", "Australia", "Europe", "North America", "South America"]
for option in continents {
    form.last! <<< ListCheckRow<String>(option){ listRow in
        listRow.title = option
        listRow.selectableValue = option
        listRow.value = nil
    }
}
```

on could do the following as well, which can be used without a reference to form and a force unwrapped reference to the last section:
```swift
form +++ SelectableSection<ListCheckRow<String>>("Where do you live", selectionType: .singleSelection(enableDeselection: true))

<<<  ["Africa", "Antarctica", "Asia", "Australia", "Europe", "North America", "South America"].map { title in 
   return ListCheckRow<String>(title){ listRow in
        listRow.title = title
        listRow.selectableValue = title
        listRow.value = nil
    }
}
```