### PR TITLE
Update README (remove section header string literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,8 +1021,6 @@ Look at this [issue](https://github.com/xmartlabs/Eureka/issues/96).
 * Set up a new header/footer data ....
 
 ```swift
-section.header = "Header Title" // use string literal as a header/footer data. HeaderFooterView conforms to ExpressibleByStringLiteral.
-//or
 section.header = HeaderFooterView(title: "Header title \(variable)") // use String interpolation
 //or
 var header = HeaderFooterView<UIView>(.class) // most flexible way to set up a header using any view type


### PR DESCRIPTION
It's not working anymore (probably a leftover in the doc)