### PR TITLE
Fixed how sections and row are inserted using subscripts

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		51729DF61B9A4F5E004A00EB /* Eureka.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51729DEB1B9A4F5E004A00EB /* Eureka.framework */; };
 		51729E671B9A5FA5004A00EB /* Eureka.h in Headers */ = {isa = PBXBuildFile; fileRef = 51729E661B9A5FA5004A00EB /* Eureka.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8690E4BE1CFDE062004CDB1C /* Eureka.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8690E4BD1CFDE062004CDB1C /* Eureka.bundle */; };
+		B257FE2E1EC0F66900043911 /* RowsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */; };
+		B2A401161EC0BA140042EDF0 /* SectionsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */; };
 		FA56B6AF1DBAD38900407C94 /* RuleEqualsToRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA56B6AE1DBAD38900407C94 /* RuleEqualsToRow.swift */; };
 /* End PBXBuildFile section */
 
@@ -178,6 +180,8 @@
 		51729DFC1B9A4F5E004A00EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		51729E661B9A5FA5004A00EB /* Eureka.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Eureka.h; path = Source/Eureka.h; sourceTree = SOURCE_ROOT; };
 		8690E4BD1CFDE062004CDB1C /* Eureka.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Eureka.bundle; sourceTree = "<group>"; };
+		B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RowsInsertionTests.swift; path = Tests/RowsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
+		B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SectionsInsertionTests.swift; path = Tests/SectionsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
 		FA56B6AE1DBAD38900407C94 /* RuleEqualsToRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RuleEqualsToRow.swift; path = Source/Validations/RuleEqualsToRow.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -358,6 +362,8 @@
 				287A142A1D89DF1E00FFE6EB /* ValidationsTests.swift */,
 				285BA4481E81864E0034EE92 /* MultivaluedSectionTests.swift */,
 				51729DFC1B9A4F5E004A00EB /* Info.plist */,
+				B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */,
+				B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */,
 			);
 			name = Tests;
 			path = EurekaTests;
@@ -556,6 +562,7 @@
 				28B1D7891C7F911900605EB3 /* CollectionTests.swift in Sources */,
 				28B1D78C1C7F911900605EB3 /* HelperMethodTests.swift in Sources */,
 				28B1D78B1C7F911900605EB3 /* FormValuesTests.swift in Sources */,
+				B2A401161EC0BA140042EDF0 /* SectionsInsertionTests.swift in Sources */,
 				28B1D7871C7F911900605EB3 /* BaseEurekaTests.swift in Sources */,
 				28B1D7911C7F911900605EB3 /* SetValuesTests.swift in Sources */,
 				285BA44A1E8187480034EE92 /* MultivaluedSectionTests.swift in Sources */,
@@ -563,6 +570,7 @@
 				28B1D78E1C7F911900605EB3 /* OperatorsTest.swift in Sources */,
 				28B1D78D1C7F911900605EB3 /* HiddenRowsTests.swift in Sources */,
 				287A14331D8A07ED00FFE6EB /* SelectableSectionTests.swift in Sources */,
+				B257FE2E1EC0F66900043911 /* RowsInsertionTests.swift in Sources */,
 				28B1D78A1C7F911900605EB3 /* DateTests.swift in Sources */,
 				287A142B1D89DF1E00FFE6EB /* ValidationsTests.swift in Sources */,
 				28B1D78F1C7F911900605EB3 /* RowByTagTests.swift in Sources */,

--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -212,6 +212,11 @@ extension BaseRow {
         removeFromRowObservers()
     }
 
+    final func willBeRemovedFromSection() {
+        willBeRemovedFromForm()
+        section = nil
+    }
+
     final func removeFromHiddenRowObservers() {
         guard let h = hidden else { return }
         switch h {

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -172,7 +172,24 @@ extension Form: MutableCollection {
 
     public subscript (_ position: Int) -> Section {
         get { return kvoWrapper.sections[position] as! Section }
-        set { kvoWrapper.sections[position] = newValue }
+        set {
+            if position > kvoWrapper.sections.count {
+                assertionFailure("Form: Index out of bounds")
+            }
+
+            if position < kvoWrapper.sections.count {
+                let oldSection = kvoWrapper.sections[position]
+                let oldSectionIndex = kvoWrapper._allSections.index(of: oldSection as! Section)!
+                // Remove the previous section from the form
+                kvoWrapper._allSections[oldSectionIndex].willBeRemovedFromForm()
+                kvoWrapper._allSections[oldSectionIndex] = newValue
+            } else {
+                kvoWrapper._allSections.append(newValue)
+            }
+
+            kvoWrapper.sections[position] = newValue
+            newValue.wasAddedTo(form: self)
+        }
     }
     public func index(after i: Int) -> Int {
         return i+1 <= endIndex ? i+1 : endIndex

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -193,6 +193,7 @@ open class Section {
 
     // MARK: Private
     lazy var kvoWrapper: KVOWrapper = { [unowned self] in return KVOWrapper(section: self) }()
+    
     var headerView: UIView?
     var footerView: UIView?
     var hiddenCache = false
@@ -211,12 +212,31 @@ extension Section : MutableCollection, BidirectionalCollection {
             }
             return kvoWrapper.rows[position] as! BaseRow
         }
-        set { kvoWrapper.rows[position] = newValue }
+        set {
+            if position > kvoWrapper.rows.count {
+                assertionFailure("Section: Index out of bounds")
+            }
+
+            if position < kvoWrapper.rows.count {
+                let oldRow = kvoWrapper.rows[position]
+                let oldRowIndex = kvoWrapper._allRows.index(of: oldRow as! BaseRow)!
+                // Remove the previous row from the form
+                kvoWrapper._allRows[oldRowIndex].willBeRemovedFromSection()
+                kvoWrapper._allRows[oldRowIndex] = newValue
+            } else {
+                kvoWrapper._allRows.append(newValue)
+            }
+
+            kvoWrapper.rows[position] = newValue
+            newValue.wasAddedTo(section: self)
+        }
     }
 
     public subscript (range: Range<Int>) -> [BaseRow] {
         get { return kvoWrapper.rows.objects(at: IndexSet(integersIn: range)) as! [BaseRow] }
-        set { kvoWrapper.rows.replaceObjects(in: NSRange(range), withObjectsFrom: newValue) }
+        set {
+            replaceSubrange(range, with: newValue)
+        }
     }
 
     public func index(after i: Int) -> Int {return i + 1}
@@ -245,7 +265,7 @@ extension Section : RangeReplaceableCollection {
     public func replaceSubrange<C: Collection>(_ subRange: Range<Int>, with newElements: C) where C.Iterator.Element == BaseRow {
         for i in subRange.lowerBound..<subRange.upperBound {
             if let row = kvoWrapper.rows.object(at: i) as? BaseRow {
-                row.willBeRemovedFromForm()
+                row.willBeRemovedFromSection()
                 kvoWrapper._allRows.remove(at: kvoWrapper._allRows.index(of: row)!)
             }
         }
@@ -262,10 +282,21 @@ extension Section : RangeReplaceableCollection {
     public func removeAll(keepingCapacity keepCapacity: Bool = false) {
         // not doing anything with capacity
         for row in kvoWrapper._allRows {
-            row.willBeRemovedFromForm()
+            row.willBeRemovedFromSection()
         }
         kvoWrapper.rows.removeAllObjects()
         kvoWrapper._allRows.removeAll()
+    }
+
+    public func remove(at position: Int) -> BaseRow {
+        let row = kvoWrapper.rows.object(at: position) as! BaseRow
+        row.willBeRemovedFromSection()
+        kvoWrapper.rows.removeObject(at: position)
+        if let index = kvoWrapper._allRows.index(of: row) {
+            kvoWrapper._allRows.remove(at: index)
+        }
+
+        return row
     }
 
     private func indexForInsertion(at index: Int) -> Int {

--- a/Tests/RowsInsertionTests.swift
+++ b/Tests/RowsInsertionTests.swift
@@ -1,0 +1,316 @@
+//
+//  RowsInsertionTests.swift
+//  Eureka
+//
+//  Created by Miguel Revetria on 5/8/17.
+//  Copyright © 2017 Xmartlabs. All rights reserved.
+//
+
+import XCTest
+@testable import Eureka
+
+class RowsInsertionTests: XCTestCase {
+    
+    func testAppendingRows() {
+        let form = Form()
+        let section = Section("section_01")
+
+        form.append(section)
+        section.append(NameRow(tag: "row_01"))
+        section.append(NameRow(tag: "row_02"))
+        section.append(NameRow(tag: "row_03"))
+
+        hideAndShowRows(form: form, expectedTags: ["row_01", "row_02", "row_03"])
+    }
+
+    func testAppendingRowsWithCustomOperator() {
+        let form = Form()
+        let section = Section("section_01")
+
+        form +++ section
+            <<< NameRow(tag: "row_01")
+            <<< NameRow(tag: "row_02")
+            <<< NameRow(tag: "row_03")
+
+        hideAndShowRows(form: form, expectedTags: ["row_01", "row_02", "row_03"])
+    }
+
+    func testInsertingRowsWithSubscript() {
+        let form = Form()
+        let section = Section("section_01")
+
+        form[0] = section
+        form[0][0] = NameRow(tag: "row_01")
+        form[0][1] = NameRow(tag: "row_02")
+        form[0][2] = NameRow(tag: "row_03")
+
+        hideAndShowRows(form: form, expectedTags: ["row_01", "row_02", "row_03"])
+    }
+
+    func testMovingAppendedRows() {
+        let formInit: () -> Form = {
+            let form = Form()
+            let section = Section()
+
+            form.append(section)
+            section.append(NameRow(tag: "tag_01"))
+            section.append(NameRow(tag: "tag_02"))
+            section.append(NameRow(tag: "tag_03"))
+
+            return form
+        }
+
+        let append: (Section, BaseRow) -> Void = { section, row in
+            section.append(row)
+        }
+
+        movingRows(formInit: formInit, sectionAppend: append)
+    }
+
+    func testMovingAppendedRowsWithCustomOperator() {
+        let formInit: () -> Form = {
+            let form = Form()
+            let section = Section()
+
+            form +++ section
+            section <<< NameRow(tag: "tag_01")
+            section <<< NameRow(tag: "tag_02")
+            section <<< NameRow(tag: "tag_03")
+
+            return form
+        }
+
+        let append: (Section, BaseRow) -> Void = { section, row in
+            section <<< row
+        }
+
+        movingRows(formInit: formInit, sectionAppend: append)
+    }
+
+    func testMovingInsertedRowsWithSubscript() {
+        let formInit: () -> Form = {
+            let form = Form()
+            let section = Section()
+
+            form[0] = section
+            section[0] = NameRow(tag: "tag_01")
+            section[1] = NameRow(tag: "tag_02")
+            section[2] = NameRow(tag: "tag_03")
+
+            return form
+        }
+
+        let append: (Section, BaseRow) -> Void = { section, row in
+            section[section.count] = row
+        }
+
+        movingRows(formInit: formInit, sectionAppend: append)
+    }
+
+    func testReplacingAppendedRows() {
+        let form = Form()
+        let section = Section()
+
+        form.append(section)
+        section.append(NameRow(tag: "tag_01"))
+        section.append(NameRow(tag: "tag_02"))
+        section.append(NameRow(tag: "tag_03"))
+
+        replaceRows(form: form)
+    }
+
+    func testReplacingAppendedRowsWithCustomOperator() {
+        let form = Form()
+        let section = Section()
+
+        form +++ section
+            <<< NameRow(tag: "tag_01")
+            <<< NameRow(tag: "tag_02")
+            <<< NameRow(tag: "tag_03")
+
+        replaceRows(form: form)
+    }
+
+    func testReplacingInsertedRowsWithSubscript() {
+        let form = Form()
+        let section = Section()
+
+        form[0] = section
+        form[0][0] = NameRow(tag: "tag_01")
+        form[0][1] = NameRow(tag: "tag_02")
+        form[0][2] = NameRow(tag: "tag_03")
+
+        replaceRows(form: form)
+    }
+
+    func testReplacingSubrangeForAppendedRows() {
+        let form = Form()
+        let section = Section()
+
+        form.append(section)
+        section.append(NameRow(tag: "tag_01"))
+        section.append(NameRow(tag: "tag_02"))
+        section.append(NameRow(tag: "tag_03"))
+
+        replaceSectionSubranges(form: form)
+    }
+
+    func testReplacingSubrangeForAppendedRowsWithCustomOperator() {
+        let form = Form()
+        let section = Section()
+
+        form +++ section
+            <<< NameRow(tag: "tag_01")
+            <<< NameRow(tag: "tag_02")
+            <<< NameRow(tag: "tag_03")
+
+        replaceSectionSubranges(form: form)
+    }
+
+    func testReplacingSubrangeForInsertedRowsWithSubscript() {
+        let form = Form()
+        let section = Section()
+
+        form[0] = section
+        form[0][0] = NameRow(tag: "tag_01")
+        form[0][1] = NameRow(tag: "tag_02")
+        form[0][2] = NameRow(tag: "tag_03")
+        
+        replaceSectionSubranges(form: form)
+    }
+
+    private func hideAndShowRows(form: Form, expectedTags tags: [String]) {
+        form.first?.forEach { row in
+            XCTAssertNotNil(row.section)
+        }
+
+        XCTAssertEqual(form[0].count, 3)
+
+        var tag1 = form[0][0].tag!
+        var tag2 = form[0][1].tag!
+        var tag3 = form[0][2].tag!
+
+        XCTAssertEqual(tag1, tags[0])
+        XCTAssertEqual(tag2, tags[1])
+        XCTAssertEqual(tag3, tags[2])
+
+        var row = form[0][1]
+        row.hidden = true
+        row.evaluateHidden()
+        XCTAssertNotNil(row.section)
+
+        XCTAssertEqual(form[0].count, 2)
+        XCTAssertEqual(form.allRows.count, 3)
+
+        tag1 = form[0][0].tag!
+        tag3 = form[0][1].tag!
+        XCTAssertEqual(tag1, tags[0])
+        XCTAssertEqual(tag3, tags[2])
+
+        row = form[0][0]
+        row.hidden = true
+        row.evaluateHidden()
+        XCTAssertNotNil(row.section)
+
+        XCTAssertEqual(form[0].count, 1)
+        XCTAssertEqual(form.allRows.count, 3)
+
+        tag3 = form[0][0].tag!
+        XCTAssertEqual(tag3, tags[2])
+
+        row = form[0][0]
+        row.hidden = true
+        row.evaluateHidden()
+        XCTAssertNotNil(row.section)
+
+        XCTAssertEqual(form[0].count, 0)
+        XCTAssertEqual(form.allRows.count, 3)
+
+        form.allRows
+            .map { $0.tag! }
+            .enumerated()
+            .forEach { ind, tag in
+                XCTAssertEqual(tag, tags[ind])
+            }
+
+        form.allRows[1].hidden = false
+        form.allRows[1].evaluateHidden()
+
+        XCTAssertEqual(form[0].count, 1)
+        XCTAssertEqual(form.allRows.count, 3)
+
+        tag2 = form[0][0].tag!
+        XCTAssertEqual(tag2, tags[1])
+    }
+
+    private func movingRows(formInit: () -> Form, sectionAppend: (Section, BaseRow) -> Void) {
+        var form = formInit()
+
+        var tmp = form[0].remove(at: 0)
+        XCTAssertNil(tmp.section)
+        sectionAppend(form[0], tmp)
+        XCTAssertNotNil(tmp.section)
+
+        hideAndShowRows(form: form, expectedTags: ["tag_02", "tag_03", "tag_01"])
+
+        form = formInit()
+        tmp = form[0].remove(at: 1)
+        XCTAssertNil(tmp.section)
+        sectionAppend(form[0], tmp)
+        XCTAssertNotNil(tmp.section)
+
+        hideAndShowRows(form: form, expectedTags: ["tag_01", "tag_03", "tag_02"])
+
+        form = formInit()
+        tmp = form[0].remove(at: 2)
+        XCTAssertNil(tmp.section)
+        sectionAppend(form[0], tmp)
+        XCTAssertNotNil(tmp.section)
+
+        hideAndShowRows(form: form, expectedTags: ["tag_01", "tag_02", "tag_03"])
+    }
+
+    private func replaceRows(form: Form) {
+        let section = form.first!
+        for ind in 0..<section.count {
+            let testTag = "tag_test_0\(ind)"
+            let testRow = NameRow(tag: testTag)
+            let row = section[ind]
+
+            XCTAssertNotNil(row.section)
+            section[ind] = testRow
+
+            XCTAssertNotNil(testRow.section)
+            XCTAssertNil(row.section)
+            XCTAssertEqual(section[ind].tag!, testTag)
+        }
+    }
+
+    private func replaceSectionSubranges(form: Form) {
+        let section = form.first!
+        let row = section.first!
+        let testRow = NameRow(tag: "tag_test_01")
+        let testRow2 = NameRow(tag: "tag_test_02")
+
+        XCTAssertNotNil(row.section)
+        section.replaceSubrange(0..<1, with: [testRow])
+        XCTAssertNotNil(testRow.section)
+        XCTAssertNil(row.section)
+        XCTAssertEqual(section.count, 3)
+
+        section.replaceSubrange(0..<1, with: [])
+        XCTAssertNil(testRow.section)
+        XCTAssertEqual(section.count, 2)
+
+        section.replaceSubrange(0..<1, with: [testRow, testRow2])
+        XCTAssertNotNil(testRow.section)
+        XCTAssertNotNil(testRow2.section)
+        XCTAssertEqual(section.count, 3)
+
+        section.replaceSubrange(0..<section.count, with: [])
+        XCTAssertNil(testRow.section)
+        XCTAssertNil(testRow2.section)
+        XCTAssertTrue(section.isEmpty)
+    }
+
+}

--- a/Tests/SectionsInsertionTests.swift
+++ b/Tests/SectionsInsertionTests.swift
@@ -1,0 +1,285 @@
+//
+//  SectionInsertionTests.swift
+//  Eureka
+//
+//  Created by Miguel Revetria on 5/8/17.
+//  Copyright © 2017 Xmartlabs. All rights reserved.
+//
+
+import XCTest
+@testable import Eureka
+
+class SectionInsertionTests: XCTestCase {
+
+    var formVC = FormViewController()
+    var form: Form!
+
+    func testAppendingSections() {
+        let form = Form()
+        form.append(Section("section_01"))
+        form.append(Section("section_02"))
+        form.append(Section("section_03"))
+
+        hideAndShowSections(
+            form: form,
+            expectedTitles: ["section_01", "section_02", "section_03"]
+        )
+    }
+
+    func testAppendingSectionsWithCustomOperator() {
+        let form = Form()
+        form +++ Section("section_01")
+        form +++ Section("section_02")
+        form +++ Section("section_03")
+
+        hideAndShowSections(
+            form: form,
+            expectedTitles: ["section_01", "section_02", "section_03"]
+        )
+    }
+
+    func testInsertingSectionsWithSubscript() {
+        let form = Form()
+        form[0] = Section("section_01")
+        form[1] = Section("section_02")
+        form[2] = Section("section_03")
+
+        hideAndShowSections(
+            form: form,
+            expectedTitles: ["section_01", "section_02", "section_03"]
+        )
+    }
+
+    func testMovingAppendedSections() {
+        let formInit: () -> Form = {
+            let form = Form()
+            form.append(Section("section_01"))
+            form.append(Section("section_02"))
+            form.append(Section("section_03"))
+            return form
+        }
+
+        let append: (Form, Section) -> Void = { form, section in
+            form.append(section)
+        }
+
+        movingSections(formInit: formInit, formAppend: append)
+    }
+
+    func testMovingAppendedSectionsWithCustomOperator() {
+        let formInit: () -> Form = {
+            let form = Form()
+            form +++ Section("section_01")
+            form +++ Section("section_02")
+            form +++ Section("section_03")
+            return form
+        }
+
+        let append: (Form, Section) -> Void = { form, section in
+            form +++ section
+        }
+
+        movingSections(formInit: formInit, formAppend: append)
+    }
+
+    func testMovingInsertedSectionsWithSubscript() {
+        let formInit: () -> Form = {
+            let form = Form()
+            form[0] = Section("section_01")
+            form[1] = Section("section_02")
+            form[2] = Section("section_03")
+            return form
+        }
+
+        let append: (Form, Section) -> Void = { form, section in
+            form[form.count] = section
+        }
+
+        movingSections(formInit: formInit, formAppend: append)
+    }
+
+    func testReplacingAppendedSections() {
+        let form = Form()
+        form.append(Section("section_01"))
+        form.append(Section("section_02"))
+        form.append(Section("section_03"))
+
+        replaceSections(form: form)
+    }
+
+    func testReplacingAppendedSectionsWithCustomOperator() {
+        let form = Form()
+        form +++ Section("section_01")
+        form +++ Section("section_02")
+        form +++ Section("section_03")
+
+        replaceSections(form: form)
+    }
+
+    func testReplacingInsertedSectionsWithSubscript() {
+        let form = Form()
+        form[0] = Section("section_01")
+        form[1] = Section("section_02")
+        form[2] = Section("section_03")
+
+        replaceSections(form: form)
+    }
+
+    func testReplacingSubrangeForAppendedSections() {
+        let form = Form()
+        form.append(Section("section_01"))
+        form.append(Section("section_02"))
+        form.append(Section("section_03"))
+
+        replaceSectionSubranges(form: form)
+    }
+
+    func testReplacingSubrangeForAppendedSectionsWithCustomOperator() {
+        let form = Form()
+        form +++ Section("section_01")
+        form +++ Section("section_02")
+        form +++ Section("section_03")
+
+        replaceSectionSubranges(form: form)
+    }
+
+    func testReplacingSubrangeForInsertedSectionsWithSubscript() {
+        let form = Form()
+        form[0] = Section("section_01")
+        form[1] = Section("section_02")
+        form[2] = Section("section_03")
+
+        replaceSectionSubranges(form: form)
+    }
+
+    private func hideAndShowSections(form: Form, expectedTitles titles: [String]) {
+        // Doesn't matter how rows were added to the form (using append, +++ or subscript index)
+        // next must work
+
+        XCTAssertEqual(form.count, 3)
+
+        var title1 = form[0].header!.title!
+        var title2 = form[1].header!.title!
+        var title3 = form[2].header!.title!
+
+        XCTAssertEqual(title1, titles[0])
+        XCTAssertEqual(title2, titles[1])
+        XCTAssertEqual(title3, titles[2])
+
+        var sect = form[1]
+        sect.hidden = true
+        sect.evaluateHidden()
+        XCTAssertNotNil(sect.form)
+
+        XCTAssertEqual(form.count, 2)
+        XCTAssertEqual(form.allSections.count, 3)
+
+        title1 = form[0].header!.title!
+        title3 = form[1].header!.title!
+        XCTAssertEqual(title1, titles[0])
+        XCTAssertEqual(title3, titles[2])
+
+        sect = form[0]
+        sect.hidden = true
+        sect.evaluateHidden()
+        XCTAssertNotNil(sect.form)
+
+        XCTAssertEqual(form.count, 1)
+        XCTAssertEqual(form.allSections.count, 3)
+
+        title3 = form[0].header!.title!
+        XCTAssertEqual(title3, titles[2])
+
+        sect = form[0]
+        sect.hidden = true
+        sect.evaluateHidden()
+        XCTAssertNotNil(sect.form)
+
+        XCTAssertEqual(form.count, 0)
+        XCTAssertEqual(form.allSections.count, 3)
+
+        form.allSections
+            .map { $0.header!.title! }
+            .enumerated()
+            .forEach { ind, title in
+                XCTAssertEqual(title, titles[ind])
+            }
+
+        form.allSections[1].hidden = false
+        form.allSections[1].evaluateHidden()
+
+        XCTAssertEqual(form.count, 1)
+        XCTAssertEqual(form.allSections.count, 3)
+
+        title2 = form[0].header!.title!
+        XCTAssertEqual(title2, titles[1])
+    }
+
+    private func movingSections(formInit: () -> Form, formAppend: (Form, Section) -> Void) {
+        var form = formInit()
+        var tmp = form.remove(at: 0)
+        XCTAssertNil(tmp.form)
+        formAppend(form, tmp)
+        XCTAssertNotNil(tmp.form)
+
+        hideAndShowSections(form: form, expectedTitles: ["section_02", "section_03", "section_01"])
+
+        form = formInit()
+        tmp = form.remove(at: 1)
+        XCTAssertNil(tmp.form)
+        formAppend(form, tmp)
+        XCTAssertNotNil(tmp.form)
+
+        hideAndShowSections(form: form, expectedTitles: ["section_01", "section_03", "section_02"])
+
+        form = formInit()
+        tmp = form.remove(at: 2)
+        XCTAssertNil(tmp.form)
+        formAppend(form, tmp)
+        XCTAssertNotNil(tmp.form)
+
+        hideAndShowSections(form: form, expectedTitles: ["section_01", "section_02", "section_03"])
+    }
+
+    private func replaceSections(form: Form) {
+        for ind in 0..<form.count {
+            let testTitle = "section_test_\(ind)"
+            let testSection = Section(testTitle)
+            let section = form[ind]
+
+            XCTAssertNotNil(section.form)
+            form[ind] = testSection
+
+            XCTAssertNotNil(testSection.form)
+            XCTAssertNil(section.form)
+            XCTAssertEqual(form[ind].header!.title!, testTitle)
+        }
+    }
+
+    private func replaceSectionSubranges(form: Form) {
+        let section = form.first!
+        let testSection = Section("section_test_01")
+        let testSection2 = Section("section_test_02")
+
+        XCTAssertNotNil(section.form)
+        form.replaceSubrange(0..<1, with: [testSection])
+        XCTAssertNotNil(testSection.form)
+        XCTAssertNil(section.form)
+        XCTAssertEqual(form.count, 3)
+
+        form.replaceSubrange(0..<1, with: [])
+        XCTAssertNil(testSection.form)
+        XCTAssertEqual(form.count, 2)
+
+        form.replaceSubrange(0..<1, with: [testSection, testSection2])
+        XCTAssertNotNil(testSection.form)
+        XCTAssertNotNil(testSection2.form)
+        XCTAssertEqual(form.count, 3)
+
+        form.replaceSubrange(0..<form.count, with: [])
+        XCTAssertNil(testSection.form)
+        XCTAssertNil(testSection2.form)
+        XCTAssertTrue(form.isEmpty)
+    }
+
+}


### PR DESCRIPTION
How it's pointed out in this issue #1024, if either sections or rows are added to the form using subscripts then they wont be correctly handled. For example `form[0][0].reload()` won't work if the rows was added in this way `form[0][0] = SomeRow()`

The changes fix how the sections and rows are inserted into the form, key points are:
* add sections and rows to `_allSections` and `_allRows` respectively
* call `wasAddedTo()` to each section and row added
* call `willBeRemovedFromForm` to each of the section and row that are being replaced.

Previous changes made subscripts works in the same way that `append` does

Fixes #1024 
