### PR TITLE
Remove observers in viewWillDisappear

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -516,8 +516,8 @@ open class FormViewController: UIViewController, FormViewControllerProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(FormViewController.keyboardWillHide(_:)), name: Notification.Name.UIKeyboardWillHide, object: nil)
     }
 
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: Notification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.removeObserver(self, name: Notification.Name.UIKeyboardWillHide, object: nil)
     }


### PR DESCRIPTION
Removing the observers in `viewDidDisappear` leads to an issue with the interactive dismissal of `UIViewController`s.
When the interactive dismissal begins, `viewWillDisappear` is called and then, if the gesture in cancelled, `viewWillAppear` and `viewDidAppear` are called again but not `viewDidDisappear`.

This way, every time a dismissal is cancelled a new observer is added without removing the previous one. This results in multiple calls to `keyboardWillShow/Hide` when the keyboard is presented/dismissed.

Moving the `removeObserver` calls to `viewWillDisappear` should fix the issue.