### PR TITLE
Fixes #977

### DIFF
--- a/Example/Example/CustomRows/ImageRow/ImageRow.swift
+++ b/Example/Example/CustomRows/ImageRow/ImageRow.swift
@@ -167,16 +167,21 @@ open class _ImageRow<Cell: CellType>: SelectorRow<Cell, ImagePickerController> w
     
     open override func customUpdateCell() {
         super.customUpdateCell()
+        
         cell.accessoryType = .none
+        cell.editingAccessoryView = .none
+        
         if let image = self.value {
             let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
             imageView.contentMode = .scaleAspectFill
             imageView.image = image
             imageView.clipsToBounds = true
+            
             cell.accessoryView = imageView
-        }
-        else{
+            cell.editingAccessoryView = imageView
+        } else {
             cell.accessoryView = nil
+            cell.editingAccessoryView = nil
         }
     }
     


### PR DESCRIPTION
When an `imageRow` is in a `MultivaluedSection` the image isn't showed because the reorder control takes the `accesoryView`'s place.
In these changes the image is also set to the `editingAccesoryView` so that it is always shown, even when the `tableView` is in edit mode.