### PR TITLE
Implemented lazy options provider for SelectorViewController

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -249,6 +249,22 @@ class RowsExampleViewController: FormViewController {
                             default: return ""
                             }
                         }
+                    }
+            <<< PushRow<Emoji>() {
+                $0.title = "LazySectionedPushRow"
+                $0.value = 👦🏼
+                $0.selectorTitle = "Choose a lazy Emoji!"
+                }.onPresent { from, to in
+                    to.row.dataProvider = nil
+                    to.optionsProvider = .lazy({ (form, completion) in
+                        let activityView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+                        form.tableView.backgroundView = activityView
+                        activityView.startAnimating()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {
+                            form.tableView.backgroundView = nil
+                            completion([💁🏻, 🍐, 👦🏼, 🐗, 🐼, 🐻])
+                        })
+                    })
         }
 
         

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -315,6 +315,23 @@ class RowsExampleViewController: FormViewController {
                             }
                         }
                         to.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: from, action: #selector(RowsExampleViewController.multipleSelectorDone(_:)))
+                    }
+            <<< MultipleSelectorRow<Emoji>() {
+                $0.title = "LazyMultipleSelectorRow"
+                $0.value = [👦🏼, 🍐, 🐗]
+                }.onPresent { from, to in
+                    to.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: from, action: #selector(RowsExampleViewController.multipleSelectorDone(_:)))
+
+                    to.row.dataProvider = nil
+                    to.optionsProvider = .lazy({ (form, completion) in
+                        let activityView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+                        form.tableView.backgroundView = activityView
+                        activityView.startAnimating()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: {
+                            form.tableView.backgroundView = nil
+                            completion([💁🏻, 🍐, 👦🏼, 🐗, 🐼, 🐻])
+                        })
+                    })
         }
         
         form +++ Section("Generic picker")

--- a/Tests/SelectableSectionTests.swift
+++ b/Tests/SelectableSectionTests.swift
@@ -178,4 +178,33 @@ class SelectableSectionTests: XCTestCase {
         XCTAssertEqual(form[2].flatMap({ ($0 as! ListCheckRow<String>).selectableValue }), ["Antarctica"])
     }
 
+    func testLazyOptionsProvider() {
+        let selectorViewController = SelectorViewController<String>(nibName: nil, bundle: nil)
+        let row = PushRow<String>()
+        selectorViewController.row = row
+        let options = ["Africa", "Antarctica", "Asia", "Australia", "Europe", "North America", "South America"]
+        
+        let optionsFetched = expectation(description: "Fetched options")
+        selectorViewController.optionsProvider = .lazy({ form, completion in
+            DispatchQueue.main.async {
+                completion(options)
+                optionsFetched.fulfill()
+            }
+        })
+
+        let form = selectorViewController.form
+        
+        XCTAssertEqual(form.count, 0)
+
+        selectorViewController.view.frame = CGRect(x: 0, y: 0, width: 375, height: 3000)
+        selectorViewController.tableView?.frame = selectorViewController.view.frame
+        
+        waitForExpectations(timeout: 1, handler: nil)
+        
+        XCTAssertEqual(row.options, options)
+        XCTAssertEqual(form.count, 1)
+        XCTAssertEqual(form[0].count, options.count)
+        XCTAssertEqual(form[0].flatMap({ ($0 as! ListCheckRow<String>).selectableValue }), options)
+    }
+    
 }


### PR DESCRIPTION
This PR adds option to implement custom data provider for options selector, i.e. when options need to be fetched from remote source. After options are fetched they are cached unless provider is not reset to `nil`, which cleans the cash.