### PR TITLE
Custom SelectorViewController headers and footers

### DIFF
--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -173,6 +173,22 @@ open class Section {
         self.footer = HeaderFooterView(stringLiteral: footer)
         initializer(self)
     }
+    
+    public init(_ header: HeaderFooterViewRepresentable, _ initializer: (Section) -> Void = { _ in }) {
+        self.header = header
+        initializer(self)
+    }
+    
+    public init(header: HeaderFooterViewRepresentable, footer: HeaderFooterViewRepresentable, _ initializer: (Section) -> Void = { _ in }) {
+        self.header = header
+        self.footer = footer
+        initializer(self)
+    }
+    
+    public init(footer: HeaderFooterViewRepresentable, _ initializer: (Section) -> Void = { _ in }) {
+        self.footer = footer
+        initializer(self)
+    }
 
     // MARK: SectionDelegate
 

--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -136,6 +136,16 @@ open class SelectableSection<Row: SelectableRowType> : Section, SelectableSectio
         super.init(header: header, footer: footer, { section in initializer(section as! SelectableSection<Row>) })
     }
 
+    public init(_ header: HeaderFooterViewRepresentable, selectionType: SelectionType, _ initializer: (SelectableSection<Row>) -> Void = { _ in }) {
+        self.selectionType = selectionType
+        super.init(header, { section in initializer(section as! SelectableSection<Row>) })
+    }
+    
+    public init(header: HeaderFooterViewRepresentable, footer: HeaderFooterViewRepresentable, selectionType: SelectionType, _ initializer: (SelectableSection<Row>) -> Void = { _ in }) {
+        self.selectionType = selectionType
+        super.init(header: header, footer: footer, { section in initializer(section as! SelectableSection<Row>) })
+    }
+    
     public required init() {
         super.init()
     }

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -48,6 +48,9 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
 
     /// A closure that returns footer title for a section for particular key.
     public var sectionFooterTitleForKey: ((String) -> String?)?
+    
+    public var sectionHeader: ((String) -> HeaderFooterViewRepresentable?)?
+    public var sectionFooter: ((String) -> HeaderFooterViewRepresentable?)?
 
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -72,10 +75,28 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
 
         if let optionsBySections = self.optionsBySections() {
             for (sectionKey, options) in optionsBySections {
-                form +++ section(with: options, header: sectionHeaderTitleForKey?(sectionKey), footer: sectionFooterTitleForKey?(sectionKey))
+                let header: HeaderFooterViewRepresentable?
+                if let sectionHeader = sectionHeader {
+                    header = sectionHeader(sectionKey)
+                } else {
+                    header = HeaderFooterView(stringLiteral: sectionHeaderTitleForKey?(sectionKey) ?? "")
+                }
+                let footer: HeaderFooterViewRepresentable?
+                if let sectionFooter = sectionFooter {
+                    footer = sectionFooter(sectionKey)
+                } else {
+                    footer = HeaderFooterView(stringLiteral: sectionFooterTitleForKey?(sectionKey) ?? "")
+                }
+                form +++ section(with: options,  header: header, footer: footer)
             }
         } else {
-            form +++ section(with: options, header: row.title, footer: nil)
+            let header: HeaderFooterViewRepresentable?
+            if let sectionHeader = sectionHeader {
+                header = row.title.flatMap(sectionHeader)
+            } else {
+                header = row.title.map(HeaderFooterView.init(stringLiteral:))
+            }
+            form +++ section(with: options, header: header, footer: nil)
         }
     }
 
@@ -92,9 +113,9 @@ open class _SelectorViewController<Row: SelectableRowType>: FormViewController, 
         return sections.sorted(by: { (lhs, rhs) in lhs.0 < rhs.0 })
     }
 
-    func section(with options: [Row.Cell.Value], header: String?, footer: String?) -> SelectableSection<Row> {
-        let header = header ?? ""
-        let footer = footer ?? ""
+    func section(with options: [Row.Cell.Value], header: HeaderFooterViewRepresentable?, footer: HeaderFooterViewRepresentable?) -> SelectableSection<Row> {
+        let header = header ?? HeaderFooterView(stringLiteral: "")
+        let footer = footer ?? HeaderFooterView(stringLiteral: "")
         let section = SelectableSection<Row>(header: header, footer: footer, selectionType: .singleSelection(enableDeselection: enableDeselection)) { [weak self] section in
             section.onSelectSelectableRow = { _, row in
                 let changed = self?.row.value != row.value


### PR DESCRIPTION
This PR adds an option to change default headers in options selector which is currently built with system style headers and to change this requires subclassing and changing headers manually after form is setup.