### PR TITLE
Fix #924

### DIFF
--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -86,7 +86,7 @@ extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIt
         for row in rows {
             if let row = row as? SelectableRow {
                 row.onCellSelection { [weak self] cell, row in
-                    guard let s = self else { return }
+                    guard let s = self, !row.isDisabled else { return }
                     switch s.selectionType {
                     case .multipleSelection:
                         row.value = row.value == nil ? row.selectableValue : nil


### PR DESCRIPTION
When a row that is inside a `SelectableSection` was disabled, the rows could still be selected. This was due to a missing check in the `SelectableSectionType` if the row was disabled.