### PR TITLE
Fixed #942

### DIFF
--- a/Source/Rows/SliderRow.swift
+++ b/Source/Rows/SliderRow.swift
@@ -97,6 +97,7 @@ open class SliderCell: Cell<Float>, CellType {
         valueLabel.isHidden = !shouldShowTitle && !awakeFromNibCalled
         titleLabel.isHidden = valueLabel.isHidden
         slider.value = row.value ?? 0.0
+        slider.isEnabled = !row.isDisabled
     }
 
     func addConstraints() {


### PR DESCRIPTION
Fixes the issue #942. The slider was not being disabled when the `SliderRow` was set disabled. This was due to the missing check if the row is disabled in the cell update