### PR TITLE
Improved logic to allow changing the default cell height easier.

### DIFF
--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -106,7 +106,6 @@ open class Cell<T: Equatable> : BaseCell, TypedCellType {
 
     required public init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        height = { UITableViewAutomaticDimension }
     }
 
     /**

--- a/Source/Rows/DatePickerRow.swift
+++ b/Source/Rows/DatePickerRow.swift
@@ -49,6 +49,7 @@ open class DatePickerCell: Cell<Date>, CellType {
         selectionStyle = .none
         accessoryType = .none
         editingAccessoryType =  .none
+        height = { UITableViewAutomaticDimension }
         datePicker.datePickerMode = datePickerMode()
         datePicker.addTarget(self, action: #selector(DatePickerCell.datePickerValueChanged(_:)), for: .valueChanged)
     }

--- a/Source/Rows/PickerInlineRow.swift
+++ b/Source/Rows/PickerInlineRow.swift
@@ -38,6 +38,7 @@ open class PickerInlineCell<T: Equatable> : Cell<T>, CellType {
         super.setup()
         accessoryType = .none
         editingAccessoryType =  .none
+        height = { UITableViewAutomaticDimension }
     }
 
     open override func update() {

--- a/Source/Rows/PickerRow.swift
+++ b/Source/Rows/PickerRow.swift
@@ -52,6 +52,7 @@ open class PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerVi
         super.setup()
         accessoryType = .none
         editingAccessoryType = .none
+        height = { UITableViewAutomaticDimension }
         picker.delegate = self
         picker.dataSource = self
     }

--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -98,7 +98,6 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
 
     open override func setup() {
         super.setup()
-        height = { BaseRow.estimatedRowHeight }
         selectionStyle = .none
         segmentedControl.addTarget(self, action: #selector(SegmentedCell.valueChanged), for: .valueChanged)
     }

--- a/Source/Rows/StepperRow.swift
+++ b/Source/Rows/StepperRow.swift
@@ -33,8 +33,6 @@ open class StepperCell: Cell<Double>, CellType {
         addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[v]-[s]-|", options: .alignAllCenterY, metrics: nil, views: ["s": stepper, "v": valueLabel]))
         addConstraint(NSLayoutConstraint(item: stepper, attribute: .centerY, relatedBy: .equal, toItem: contentView, attribute: .centerY, multiplier: 1.0, constant: 0))
         addConstraint(NSLayoutConstraint(item: valueLabel, attribute: .centerY, relatedBy: .equal, toItem: stepper, attribute: .centerY, multiplier: 1.0, constant: 0))
-
-        height = { BaseRow.estimatedRowHeight }
     }
 
     required public init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This makes it possible to easily change the default cell height for all cells by changing the `tableView.rowHeight` property on `FormViewController`.

The reason why this did not previously work was that `height` was always set in the base `Cell` implementation.

Please note that this change shouldn't affect pickers; they are still using `UITableViewAutomaticDimension`. This goes for inline pickers as well.

I tested this with the Example app included in the workspace and it worked for all cells present.