### PR TITLE
Fixed array slice for Swift 3.2

### DIFF
--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -232,8 +232,8 @@ extension Section : MutableCollection, BidirectionalCollection {
         }
     }
 
-    public subscript (range: Range<Int>) -> [BaseRow] {
-        get { return kvoWrapper.rows.objects(at: IndexSet(integersIn: range)) as! [BaseRow] }
+    public subscript (range: Range<Int>) -> ArraySlice<BaseRow> {
+        get { return ArraySlice<BaseRow>(kvoWrapper.rows.objects(at: IndexSet(integersIn: range)) as! [BaseRow]) }
         set {
             replaceSubrange(range, with: newValue)
         }


### PR DESCRIPTION
This should fix #1082, I've tried running the example app on an iOS 11 beta device and it all seemed to be working properly.
I could not run the app or the unit tests on the simulator due to an Xcode problem though.