### PR TITLE
Fix SelectableSection issue with filter

### DIFF
--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -61,7 +61,7 @@ public protocol SelectableSectionType: Collection {
     func selectedRows() -> [SelectableRow]
 }
 
-extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIterator<Section>, Self.Iterator.Element == BaseRow {
+extension SelectableSectionType where Self: Section {
 
     /**
      Returns the selected row of this section. Should be used if selectionType is SingleSelection
@@ -74,9 +74,9 @@ extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIt
      Returns the selected rows of this section. Should be used if selectionType is MultipleSelection
      */
     public func selectedRows() -> [SelectableRow] {
-        return filter({ (row: BaseRow) -> Bool in
+        return (kvoWrapper.rows as! [BaseRow]).filter { (row: BaseRow) -> Bool in
             row is SelectableRow && row.baseValue != nil
-        }).map({ $0 as! SelectableRow})
+        }.map { $0 as! SelectableRow }
     }
 
     /**
@@ -93,7 +93,7 @@ extension SelectableSectionType where Self: Section, Self.Iterator == IndexingIt
                     case .multipleSelection:
                         row.value = row.value == nil ? row.selectableValue : nil
                     case let .singleSelection(enableDeselection):
-                        s.filter { $0.baseValue != nil && $0 != row }.forEach {
+                        (s.kvoWrapper.rows as! [BaseRow]).filter { $0.baseValue != nil && $0 != row }.forEach {
                             $0.baseValue = nil
                             $0.updateCell()
                         }


### PR DESCRIPTION
It seems that `filter` creates a new and appends objects in there. In the case of filtering in a Section it creates a new `Section` and calls `append` which in turn calls a lot of functions that should not be called when filtering a Section. This changes fix some breakages.

Weird is that calling filter on a Section from a View Controller does not break anything (does not call `append` either) so that the issue might be only related to concretely casted SelectableSection's