### PR TITLE
Improve currency formatter

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -1000,7 +1000,7 @@ class FormatterExample : FormViewController {
             guard obj != nil else { return }
             var str = string.components(separatedBy: CharacterSet.decimalDigits.inverted).joined(separator: "")
             
-            if self.numberStyle == .currency && !string.contains(self.currencySymbol) {
+            if !string.isEmpty, self.numberStyle == .currency && !string.contains(self.currencySymbol) {
                 // Check if the currency symbol is at the last index
                 if let formattedNumber = self.string(from: 1),
                     formattedNumber.substring(from: formattedNumber.index(before: formattedNumber.endIndex)) == self.currencySymbol {

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -998,7 +998,17 @@ class FormatterExample : FormViewController {
     class CurrencyFormatter : NumberFormatter, FormatterProtocol {
         override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, range rangep: UnsafeMutablePointer<NSRange>?) throws {
             guard obj != nil else { return }
-            let str = string.components(separatedBy: CharacterSet.decimalDigits.inverted).joined(separator: "")
+            var str = string.components(separatedBy: CharacterSet.decimalDigits.inverted).joined(separator: "")
+            
+            if self.numberStyle == .currency && !string.contains(self.currencySymbol) {
+                // Check if the currency symbol is at the last index
+                if let formattedNumber = self.string(from: 1),
+                    formattedNumber.substring(from: formattedNumber.index(before: formattedNumber.endIndex)) == self.currencySymbol {
+                    // This means the user has deleted the currency symbol. We cut the last number and then add the symbol automatically
+                    str = str.substring(to: str.index(before: str.endIndex))
+                }
+            }
+            
             obj?.pointee = NSNumber(value: (Double(str) ?? 0.0)/Double(pow(10.0, Double(minimumFractionDigits))))
         }
         


### PR DESCRIPTION
The example project implements a currency formatter. It works very well most of the time.

Consider the following scenario:
The user has a European locale with the € currency.
Numbers are formatted the following way: 12,43 €
When the user taps into the currency style row in the example, the cursor is placed after the € sign.
The way the formatter currently works, the user can not delete any number from that location. He has to manually move the cursor to some position before the € sign. 

The code in this PR checks if the last sign is the current currency sign and if it is missing from the edited string. Then he deletes the last number. 