### PR TITLE
iOS11 SwipeActions

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		49ADC7F91C8A83240073952B /* StepperRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ADC7F81C8A83240073952B /* StepperRow.swift */; };
 		51729DF61B9A4F5E004A00EB /* Eureka.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51729DEB1B9A4F5E004A00EB /* Eureka.framework */; };
 		51729E671B9A5FA5004A00EB /* Eureka.h in Headers */ = {isa = PBXBuildFile; fileRef = 51729E661B9A5FA5004A00EB /* Eureka.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		798C5ADA1EF1E35600A21F52 /* SwipeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798C5AD91EF1E35600A21F52 /* SwipeActions.swift */; };
 		8690E4BE1CFDE062004CDB1C /* Eureka.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8690E4BD1CFDE062004CDB1C /* Eureka.bundle */; };
 		B257FE2E1EC0F66900043911 /* RowsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */; };
 		B2A401161EC0BA140042EDF0 /* SectionsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */; };
@@ -179,6 +180,7 @@
 		51729DF51B9A4F5E004A00EB /* EurekaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EurekaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		51729DFC1B9A4F5E004A00EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		51729E661B9A5FA5004A00EB /* Eureka.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Eureka.h; path = Source/Eureka.h; sourceTree = SOURCE_ROOT; };
+		798C5AD91EF1E35600A21F52 /* SwipeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActions.swift; sourceTree = "<group>"; };
 		8690E4BD1CFDE062004CDB1C /* Eureka.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Eureka.bundle; sourceTree = "<group>"; };
 		B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RowsInsertionTests.swift; path = Tests/RowsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
 		B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SectionsInsertionTests.swift; path = Tests/SectionsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
@@ -225,6 +227,7 @@
 				28EEBFF71C7E241200300699 /* SelectableRowType.swift */,
 				2859CDBF1C7D138D0002982F /* Section.swift */,
 				2859CE231C7E141B0002982F /* SelectableSection.swift */,
+				798C5AD91EF1E35600A21F52 /* SwipeActions.swift */,
 				28EE0FDD1D5E889F00B91340 /* Validation.swift */,
 			);
 			name = Core;
@@ -530,6 +533,7 @@
 				49ADC7F91C8A83240073952B /* StepperRow.swift in Sources */,
 				28EE46AC1C7F712300EFF4A2 /* DateInlineRow.swift in Sources */,
 				28EEC01C1C7E3A7400300699 /* ButtonRowWithPresent.swift in Sources */,
+				798C5ADA1EF1E35600A21F52 /* SwipeActions.swift in Sources */,
 				28EEBFF41C7E240000300699 /* RowProtocols.swift in Sources */,
 				28EEBFFE1C7E281F00300699 /* CheckRow.swift in Sources */,
 				2859CDC41C7D19C50002982F /* HeaderFooterView.swift in Sources */,

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="6g3-M9-WkD">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="6g3-M9-WkD">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -172,6 +172,7 @@
                         <segue destination="1By-iT-GXN" kind="push" identifier="ValidationsControllerSegue" id="e8a-Jy-4iL"/>
                         <segue destination="1Eh-Nv-AVS" kind="push" identifier="CustomDesignControllerSegue" id="qm6-xE-x5d"/>
                         <segue destination="qIY-1j-dNf" kind="push" identifier="MultivaluedSectionsControllerSegue" id="HjC-JK-Qvc"/>
+                        <segue destination="fc5-sQ-cEm" kind="push" identifier="SwipeActionsControllerSegue" id="AxK-me-pi6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Eoz-Jq-Zy9" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -263,6 +264,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jCh-aA-iuT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="463" y="1077"/>
+        </scene>
+        <!--SwipeActions Example-->
+        <scene sceneID="h0m-5n-GTL">
+            <objects>
+                <viewController title="SwipeActions Example" id="fc5-sQ-cEm" customClass="SwipeActionsController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="ImV-ow-JvS"/>
+                        <viewControllerLayoutGuide type="bottom" id="3OX-ei-O2d"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="BDe-QW-0vU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="KY1-r2-ar2"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="axy-1K-pFt" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-530" y="1833"/>
         </scene>
         <!--Multivalued Sections Example-->
         <scene sceneID="zbo-bQ-HRw">
@@ -652,9 +672,4 @@
             <point key="canvasLocation" x="859" y="1833"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -106,15 +106,11 @@ class HomeViewController : FormViewController {
                     row.title = row.tag
                     row.presentationMode = .segueName(segueName: "MultivaluedSectionsControllerSegue", onDismiss: nil)
                 }
-            
-                
-        +++ Section()
-                <<< ButtonRow() { (row: ButtonRow) -> Void in
-                   row.title = "About"
-                }
-                .onCellSelection { [weak self] (cell, row) in
-                    self?.showAlert()
-                }
+			
+				<<< ButtonRow("Swipe Actions") { (row: ButtonRow) -> Void in
+					row.title = row.tag
+					row.presentationMode = .segueName(segueName: "SwipeActionsControllerSegue", onDismiss: nil)
+				}
     }
     
     
@@ -1679,6 +1675,64 @@ class MultivaluedOnlyDeleteController: FormViewController {
         editButton.title = tableView.isEditing ? "Done" : "Edit"
         
     }
+}
+
+class SwipeActionsController: FormViewController {
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		form +++ Section(footer: "Eureka sets table.isEditing = false for SwipeActions.\n\nMultivaluedSections need table.isEditing = true, therefore both can't be used on the same view.")
+			<<< LabelRow("Actions Right: iOS >= 7"){
+				$0.title = $0.tag
+				
+				$0.trailingSwipeConfiguration = SwipeConfiguration(){
+					let moreAction = SwipeAction(style: .normal, title: "More", handler: { (action, path, completionHandler) in
+						print("More")
+						completionHandler?(true)
+					})
+					
+					let deleteAction = SwipeAction(style: .destructive, title: "Delete", handler: { (action, path, completionHandler) in
+						print("Delete")
+						completionHandler?(true)
+					})
+					
+					$0.actions = [deleteAction,moreAction]
+				}
+			}
+			
+			<<< LabelRow("Actions Left & Right: iOS >= 11"){
+				$0.title = $0.tag
+				
+				$0.trailingSwipeConfiguration = SwipeConfiguration(){
+					let moreAction = SwipeAction(style: .normal, title: "More", handler: { (action, path, completionHandler) in
+						print("More")
+						completionHandler?(true)
+					})
+					
+					let deleteAction = SwipeAction(style: .destructive, title: "Delete", handler: { (action, path, completionHandler) in
+						print("Delete")
+						completionHandler?(true)
+					})
+					
+					$0.performsFirstActionWithFullSwipe = true
+					$0.actions = [deleteAction,moreAction]
+				}
+				
+				if #available(iOS 11,*){
+					$0.leadingSwipeConfiguration = SwipeConfiguration(){
+						let infoAction = SwipeAction(style: .normal, title: "Info", handler: { (action, path, completionHandler) in
+							print("Info")
+							completionHandler?(true)
+						})
+						infoAction.backgroundColor = .blue
+						
+						$0.performsFirstActionWithFullSwipe = true
+						$0.actions = [infoAction]
+					}
+				}
+		}
+	}
 }
 
 class EurekaLogoViewNib: UIView {

--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -97,6 +97,17 @@ open class BaseRow: BaseRowType {
 
     /// The section to which this row belongs.
     public weak var section: Section?
+	
+	public var trailingSwipeConfiguration: SwipeConfiguration?
+	
+	//needs the accessor because if marked directly this throws "Stored properties cannot be marked potentially unavailable with '@available'"
+	private var _leadingSwipeConfiguration: SwipeConfiguration?
+	
+	@available(iOS 11,*)
+	public var leadingSwipeConfiguration: SwipeConfiguration?{
+		get{ return self._leadingSwipeConfiguration }
+		set{ self._leadingSwipeConfiguration = newValue }
+	}
 
     public required init(tag: String? = nil) {
         self.tag = tag

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -360,6 +360,12 @@ extension Form {
         }
         kvoWrapper.sections.insert(section, at: formIndex == NSNotFound ? 0 : formIndex + 1 )
     }
+
+	var containsMultivaluedSection: Bool{
+		return kvoWrapper.sections.contains { (section) -> Bool in
+			return section is MultivaluedSection
+		}
+	}
 }
 
 extension Form {

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -454,7 +454,7 @@ open class MultivaluedSection: Section {
         let addRow = addButtonProvider(self)
         addRow.onCellSelection { cell, row in
             guard let tableView = cell.formViewController()?.tableView, let indexPath = row.indexPath else { return }
-            cell.formViewController()?.tableView(tableView, commit: .insert, forRowAt: indexPath)
+		    cell.formViewController()?.tableView(tableView, commit: .insert, forRowAt: indexPath)
         }
         self <<< addRow
     }

--- a/Source/Core/SwipeActions.swift
+++ b/Source/Core/SwipeActions.swift
@@ -1,0 +1,134 @@
+//
+//  Swipe.swift
+//  Eureka
+//
+//  Created by Marco Betschart on 14.06.17.
+//  Copyright © 2017 Xmartlabs. All rights reserved.
+//
+
+import Foundation
+
+public typealias SwipeActionHandler = (Any, Any, ((Bool) -> Void)?) -> Void
+
+
+public class SwipeAction{
+	
+	public let platformValue: Any
+	
+	public var backgroundColor: UIColor?{
+		didSet{
+			if #available(iOS 11, *), let platformValue = self.platformValue as? UIContextualAction{
+				platformValue.backgroundColor = self.backgroundColor
+			}
+		}
+	}
+	
+	public var image: UIImage?{
+		didSet{
+			if #available(iOS 11, *), let platformValue = self.platformValue as? UIContextualAction{
+				platformValue.image = self.image
+			}
+		}
+	}
+	
+	public var title: String?{
+		didSet{
+			if #available(iOS 11, *), let platformValue = self.platformValue as? UIContextualAction{
+				platformValue.title = self.title
+			}
+		}
+	}
+	
+	public let handler: SwipeActionHandler
+	public let style: Style
+	
+	public init(style: Style, title: String?, handler: @escaping SwipeActionHandler){
+		self.style = style
+		self.handler = handler
+		self.title = title
+		
+		if #available(iOS 11, *){
+			self.platformValue = UIContextualAction(style: style.platformValue as! UIContextualAction.Style, title: title){ action, view, completion -> Void in
+				handler(action,view,completion)
+			}
+			
+		} else {
+			self.platformValue = UITableViewRowAction(style: style.platformValue as! UITableViewRowActionStyle,title: title){ (action, indexPath) -> Void in
+				handler(action,indexPath,nil)
+			}
+		}
+	}
+	
+	public enum Style: Int{
+		case normal = 0
+		case destructive = 1
+		
+		var platformValue: Any{
+			if #available(iOS 11, *){
+				switch self{
+				case .normal:
+					return UIContextualAction.Style.normal
+				case .destructive:
+					return UIContextualAction.Style.destructive
+				}
+				
+			} else {
+				switch self{
+				case .normal:
+					return UITableViewRowActionStyle.normal
+				case .destructive:
+					return UITableViewRowActionStyle.destructive
+				}
+			}
+		}
+		
+		public init(platformValue: Any){
+			if #available(iOS 11, *), let platformValue = platformValue as? UIContextualAction.Style{
+				switch platformValue{
+				case .normal:
+					self = .normal
+				case .destructive:
+					self = .destructive
+				}
+				
+			} else if let platformValue = platformValue as? UITableViewRowActionStyle{
+				switch platformValue{
+				case .normal:
+					self = .normal
+				case .destructive:
+					self = .destructive
+				case .default:
+					fatalError("Unmapped UITableViewRowActionStyle for SwipeActionStyle: \(platformValue)")
+				}
+				
+			} else {
+				fatalError("Invalid platformValue for SwipeActionStyle: \(platformValue)")
+			}
+		}
+	}
+}
+
+
+public class SwipeConfiguration{
+	
+	public init(configure: (SwipeConfiguration) -> Void){
+		configure(self)
+	}
+	
+	public var performsFirstActionWithFullSwipe: Bool = false
+	public var actions: [SwipeAction] = []
+	
+	public var platformValue: Any?{
+		guard #available(iOS 11, *) else{
+			return nil
+		}
+		let platformValue = UISwipeActionsConfiguration(actions: self.platformActions as! [UIContextualAction])
+		platformValue.performsFirstActionWithFullSwipe = self.performsFirstActionWithFullSwipe
+		
+		return platformValue
+	}
+	
+	public var platformActions: [Any]{
+		return self.actions.map{ $0.platformValue }
+	}
+}


### PR DESCRIPTION
Containing a graceful fallback to the old behaviour using `editActionForRowAt: indexPath`. This covers https://github.com/xmartlabs/Eureka/issues/105.