### PR TITLE
Updating labels after changing system font size

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -157,6 +157,7 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
         }
 
         NotificationCenter.default.addObserver(forName: Notification.Name.UIContentSizeCategoryDidChange, object: nil, queue: nil) { [weak self] _ in
+            self?.titleLabel = self?.textLabel
             self?.setNeedsUpdateConstraints()
         }
     }

--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -61,6 +61,7 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
         }
 
         NotificationCenter.default.addObserver(forName: Notification.Name.UIContentSizeCategoryDidChange, object: nil, queue: nil) { [weak self] _ in
+            self?.titleLabel = self?.textLabel
             self?.setNeedsUpdateConstraints()
         }
         contentView.addSubview(titleLabel!)

--- a/Source/Rows/SliderRow.swift
+++ b/Source/Rows/SliderRow.swift
@@ -41,8 +41,8 @@ open class SliderCell: Cell<Float>, CellType {
         NotificationCenter.default.addObserver(forName: Notification.Name.UIContentSizeCategoryDidChange, object: nil, queue: nil) { [weak self] _ in
             guard let me = self else { return }
             if me.shouldShowTitle {
-                me.contentView.addSubview(me.titleLabel)
-                me.contentView.addSubview(me.valueLabel!)
+                me.titleLabel = me.textLabel
+                me.valueLabel = me.detailTextLabel
                 me.addConstraints()
             }
         }


### PR DESCRIPTION
Fixes #1109 

When the system font size is changed, the UITableViewCell's create a new `textLabel` and `detailTextLabel`, so the pointer stored in the SegmentedRow is outdated. The issue crash is caused due to the original textLabel is removed from its superview and a new label is added.

## Additional changes
* Fixed an issue with the SliderRow, where the app wasn't crashing but text labels were duplicated. Checkout the GIF below. Instead of adding again the original labels, the proposed change updates the labels pointing to the new ones

## UI preview
* SliderRow issue:
![issue-1109](https://user-images.githubusercontent.com/4791678/27562253-2bc73a10-5aa2-11e7-81bc-44d66353c7f4.gif)

* Solved:
![issue-1109-solved](https://user-images.githubusercontent.com/4791678/27562200-d3116c9c-5aa1-11e7-8fa6-58dd66e24b7b.gif)

@xmartlabs/eureka 