### PR TITLE
change validation on demand behaviour when row was not valid

### DIFF
--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -55,7 +55,7 @@ open class RowOf<T: Equatable>: BaseRow {
             _value = newValue
             guard let _ = section?.form else { return }
             wasChanged = true
-            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || !isValid {
+            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || (!isValid && validationOptions.contains(.validatesOnDemand)) {
                 validate()
             }
         }

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -55,7 +55,7 @@ open class RowOf<T: Equatable>: BaseRow {
             _value = newValue
             guard let _ = section?.form else { return }
             wasChanged = true
-            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || (!isValid && validationOptions.contains(.validatesOnDemand)) {
+            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || (!isValid && !validationOptions.contains(.validatesOnDemand)) {
                 validate()
             }
         }

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -55,7 +55,7 @@ open class RowOf<T: Equatable>: BaseRow {
             _value = newValue
             guard let _ = section?.form else { return }
             wasChanged = true
-            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) || (!isValid && !validationOptions.contains(.validatesOnDemand)) {
+            if validationOptions.contains(.validatesOnChange) || (wasBlurred && validationOptions.contains(.validatesOnChangeAfterBlurred)) ||  (!isValid && validationOptions != .validatesOnDemand) {
                 validate()
             }
         }


### PR DESCRIPTION
Validating on demand should ONLY validate when u demand it and not, like it is now, always when something changes. I need this in a concrete project because I get strange validation behaviour if it validates all the time.