### PR TITLE
Fix SliderRow horizontal margins

### DIFF
--- a/Source/Rows/SliderRow.swift
+++ b/Source/Rows/SliderRow.swift
@@ -102,18 +102,17 @@ open class SliderCell: Cell<Float>, CellType {
 
     func addConstraints() {
         guard !awakeFromNibCalled else { return }
-        let views: [String : Any] = ["titleLabel": titleLabel, "valueLabel": valueLabel, "slider": slider]
-        //TODO: in Iphone 6 Plus hPadding should be 20
-        let metrics = ["hPadding": 15.0, "vPadding": 12.0, "spacing": 12.0]
-        if shouldShowTitle {
-            contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-hPadding-[titleLabel]-[valueLabel]-hPadding-|", options: NSLayoutFormatOptions.alignAllLastBaseline, metrics: metrics, views: views))
-            contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-vPadding-[titleLabel]-spacing-[slider]-vPadding-|", options: NSLayoutFormatOptions.alignAllLeft, metrics: metrics, views: views))
 
+        let views: [String : Any] = ["titleLabel": titleLabel, "valueLabel": valueLabel, "slider": slider]
+        let metrics = ["vPadding": 12.0, "spacing": 12.0]
+        if shouldShowTitle {
+            contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-[titleLabel]-[valueLabel]-|", options: NSLayoutFormatOptions.alignAllLastBaseline, metrics: metrics, views: views))
+            contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-vPadding-[titleLabel]-spacing-[slider]-vPadding-|", options: NSLayoutFormatOptions.alignAllLeft, metrics: metrics, views: views))
         } else {
             contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-vPadding-[slider]-vPadding-|", options: NSLayoutFormatOptions.alignAllLeft, metrics: metrics, views: views))
         }
-        contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-hPadding-[slider]-hPadding-|", options: NSLayoutFormatOptions.alignAllLastBaseline, metrics: metrics, views: views))
 
+        contentView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-[slider]-|", options: NSLayoutFormatOptions.alignAllLastBaseline, metrics: metrics, views: views))
     }
 
     func valueChanged() {


### PR DESCRIPTION
Changes the SliderRow's layout constraint to be aligned relative to the cell's margins. This makes the subviews present in the SliderRow to have the same horizontal margins that the labels from UITableViewCell.

This fixes #1127.

-- Edited --

<table>
<thead>
<tr>
<th>iPhone SE</th>
<th>iPhone 7</th>
<th>iPhone 7 Plus</th>
</tr>
</teadh>
<tr>
<td><img src="https://user-images.githubusercontent.com/4791678/28648658-be31ac0e-7245-11e7-8e97-17cbfa41f85f.png" /></td>
<td><img src="https://user-images.githubusercontent.com/4791678/28648710-17e06812-7246-11e7-823e-c0a491000760.png" /></td>
<td><img src="https://user-images.githubusercontent.com/4791678/28648686-eb43cda8-7245-11e7-9dbb-2901a6e97073.png" /></td>
</tr>
</table>
