### PR TITLE
Add support for Swift 3.1 in the Swift 3.2 branch

### DIFF
--- a/Source/Core/Helpers.swift
+++ b/Source/Core/Helpers.swift
@@ -79,6 +79,12 @@ extension NSExpression {
     }
 }
 
+// This is a workaround for warnings in the Swift 3.2 compiler that are triggered when a generic type
+// is explicitly constrained while already implicitly constrained.
+// For instance `T: Hashable where Cell.Value == Set<T>` triggers a warning on Swift 3.2 because Set already
+// has the constraint `T: Hashable`.
+// However Swift 3.1 doesn't infer this constraint, so we need to constraint explicitly. To do this,
+// we define a `_ImplicitlyHashable` type which is Any on 3.2+ and Hashable for earlier versions.
 #if swift(>=3.2)
 public typealias _ImplicitlyHashable = Any
 #else

--- a/Source/Core/Helpers.swift
+++ b/Source/Core/Helpers.swift
@@ -36,6 +36,7 @@ extension UIView {
         }
         return nil
     }
+    
 
     public func formCell() -> BaseCell? {
         if self is UITableViewCell {
@@ -77,3 +78,9 @@ extension NSExpression {
         }
     }
 }
+
+#if swift(>=3.2)
+public typealias _ImplicitlyHashable = Any
+#else
+public typealias _ImplicitlyHashable = Hashable
+#endif

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -279,8 +279,8 @@ extension Section : RangeReplaceableCollection {
             }
         }
 
-        kvoWrapper.rows.replaceObjects(in: NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound),
-                                       withObjectsFrom: newElements.map { $0 })
+        let range = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+        kvoWrapper.rows.replaceObjects(in: range, withObjectsFrom: newElements.map { $0 })
 
         kvoWrapper._allRows.insert(contentsOf: newElements, at: indexForInsertion(at: subrange.lowerBound))
         for row in newElements {
@@ -296,8 +296,8 @@ extension Section : RangeReplaceableCollection {
             }
         }
         
-        kvoWrapper.rows.replaceObjects(in: NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound),
-                                       withObjectsFrom: newElements.map { $0 })
+        let range = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+        kvoWrapper.rows.replaceObjects(in: range, withObjectsFrom: newElements.map { $0 })
         
         kvoWrapper._allRows.insert(contentsOf: newElements, at: indexForInsertion(at: subrange.lowerBound))
         for row in newElements {

--- a/Source/Rows/Common/GenericMultipleSelectorRow.swift
+++ b/Source/Rows/Common/GenericMultipleSelectorRow.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 /// Generic options selector row that allows multiple selection.
-open class GenericMultipleSelectorRow<T, Cell: CellType, VCType: TypedRowControllerType>: Row<Cell>, PresenterRowType, NoValueDisplayTextConformance
+open class GenericMultipleSelectorRow<T: _ImplicitlyHashable, Cell: CellType, VCType: TypedRowControllerType>: Row<Cell>, PresenterRowType, NoValueDisplayTextConformance
             where Cell: BaseCell, Cell.Value == Set<T>, VCType: UIViewController, VCType.RowValue == Set<T> {
 
     /// Defines how the view controller will be presented, pushed, etc.

--- a/Source/Rows/MultipleSelectorRow.swift
+++ b/Source/Rows/MultipleSelectorRow.swift
@@ -24,14 +24,14 @@
 
 import Foundation
 
-open class _MultipleSelectorRow<T, Cell>: GenericMultipleSelectorRow<T, Cell, MultipleSelectorViewController<T>> where Cell: BaseCell, Cell: CellType, Cell.Value == Set<T> {
+open class _MultipleSelectorRow<T: _ImplicitlyHashable, Cell>: GenericMultipleSelectorRow<T, Cell, MultipleSelectorViewController<T>> where Cell: BaseCell, Cell: CellType, Cell.Value == Set<T> {
     public required init(tag: String?) {
         super.init(tag: tag)
     }
 }
 
 /// A selector row where the user can pick several options from a pushed view controller
-public final class MultipleSelectorRow<T: Hashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
+public final class MultipleSelectorRow<T: _ImplicitlyHashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
     public required init(tag: String?) {
         super.init(tag: tag)
     }

--- a/Source/Rows/MultipleSelectorRow.swift
+++ b/Source/Rows/MultipleSelectorRow.swift
@@ -31,7 +31,7 @@ open class _MultipleSelectorRow<T: _ImplicitlyHashable, Cell>: GenericMultipleSe
 }
 
 /// A selector row where the user can pick several options from a pushed view controller
-public final class MultipleSelectorRow<T: _ImplicitlyHashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
+public final class MultipleSelectorRow<T: Hashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
     public required init(tag: String?) {
         super.init(tag: tag)
     }


### PR DESCRIPTION
Fixes https://github.com/xmartlabs/Eureka/issues/1178

As described in the issue above, it would be great to support both the Swift 3.1 and 3.2 compilers, at least for a little while since people will slowly transition from Xcode 8 to Xcode 9. When merged, this will allow people to develop for iOS 11 on the Xcode 9 betas all while publishing with Xcode 8 or AppCode.

Summary of changes:

 - Added back the old signature for `replaceSubrange` in `Section` and put it behind a version check. I'm not sure if there's a way to consolidate the code between the swift 3.1/3.2 methods so I'm open to suggestions.
 - Added a `_ImplicitlyHashable` type which works around a warning in the 3.2 compiler for redundant generic constraints. The workaround is described [in the code](https://github.com/xmartlabs/Eureka/pull/1199/files#diff-83e01711b59e6f7f5bad32b208fcaafeR82).

I tested the code + tests + app both in Xcode 8 and Xcode 9 beta 5. Everything compiles/runs without warnings.

Let me know if you have any questions!