### PR TITLE
Fix nil headers/footers of sections are displayed in FormViewController in Xcode 9

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -463,6 +463,10 @@ open class FormViewController: UIViewController, FormViewControllerProtocol {
             if #available(iOS 9.0, *) {
                 tableView.cellLayoutMarginsFollowReadableWidth = false
             }
+            // in Xcode 9, with plain style, estimated section header/footer heights are automatic by default and measure non-zero even for header/footer-less sections.
+            // quoted iOS 11 release notes: the iOS 11 SDK, and you don’t want to adopt self-sizing, you can restore the previous behavior by disabling estimated heights by setting a value of zero for each estimated height property. (30197915)
+            tableView.estimatedSectionHeaderHeight = 0
+            tableView.estimatedSectionFooterHeight = 0
         }
         if tableView.superview == nil {
             view.addSubview(tableView)


### PR DESCRIPTION
https://download.developer.apple.com/Documentation/Beta_Release_Notes_Sep_6_2017/iOS_11_beta_10_Release_Notes.pdf

As noted in iOS 11 release note, the default values of `estimatedSectionHeaderHeight` and `estimatedSectionFooterHeight` have changed in Xcode 9. This cause empty section headers/footers to be displayed with non-zero height even for header/footer-less sections.
To preserve iOS 10 SDK behavior, I inserted code that overrides the default values right after FormViewController creates UITableView.

This might not occur when FormViewController is initialized by a storyboard because default values are ignored by storyboards. Initializing by code should reproduce this issue.

A minimum reproducible example usecase is here:

https://github.com/banjun/EurekaXcode9/blob/e55a6465ef49f42559702e82dcef038011f7dcac/EurekaXcode9/ViewController.swift