### PR TITLE
fixed deallocating section

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -239,7 +239,10 @@ class RowsExampleViewController: FormViewController {
                         $0.options = [💁🏻, 🍐, 👦🏼, 🐗, 🐼, 🐻]
                         $0.value = 👦🏼
                         $0.selectorTitle = "Choose an Emoji!"
-                    }
+                    }.onPresent { from, to in
+                        to.dismissOnSelection = false
+                        to.dismissOnChange = false
+            }
 
                 <<< PushRow<Emoji>() {
                         $0.title = "SectionedPushRow"
@@ -247,6 +250,8 @@ class RowsExampleViewController: FormViewController {
                         $0.value = 👦🏼
                         $0.selectorTitle = "Choose an Emoji!"
                     }.onPresent { from, to in
+                        to.dismissOnSelection = false
+                        to.dismissOnChange = false
                         to.sectionKeyForValue = { option in
                             switch option {
                             case 💁🏻, 👦🏼: return "People"

--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -89,7 +89,8 @@ extension SelectableSectionType where Self: Section {
                     case .multipleSelection:
                         row.value = row.value == nil ? row.selectableValue : nil
                     case let .singleSelection(enableDeselection):
-                        s.filter { $0.baseValue != nil && $0 != row }.forEach {
+                        s.forEach {
+                            guard $0.baseValue != nil && $0 != row else { return }
                             $0.baseValue = nil
                             $0.updateCell()
                         }


### PR DESCRIPTION
Resolves #1218 

### Explanation

In Swift 4 `filter` method called in this case has a [new](https://github.com/apple/swift-evolution/blob/master/proposals/0174-filter-range-replaceable.md) behaviour. Implementation of `RangeReplaceableCollection.filter` creates new array of the same type (`SelectableSection`) by calling `init` (can be checked by adding breakpoint at `SelectableSection.init` method) and then calling `append(contentsOf:)` method, which results in adding previously selected row (only this row will have non-nil value) to this section and so overriding a reference to it from `self` (in this scope).

So basically what happens is that every time raw is selected it creates new section with just this row. Then when we leave the stack this section is being deallocated as it is not referenced anywhere else and it's no more possible to select this row, because `guard` does not pass any more. Though current section (`self` in this context) still contains this row.