### PR TITLE
Allow non-selectable rows to exist besides selectable rows

### DIFF
--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -90,7 +90,7 @@ extension SelectableSectionType where Self: Section {
                         row.value = row.value == nil ? row.selectableValue : nil
                     case let .singleSelection(enableDeselection):
                         s.forEach {
-                            guard $0.baseValue != nil && $0 != row else { return }
+                            guard $0.baseValue != nil && $0 != row && $0 is SelectableRow else { return }
                             $0.baseValue = nil
                             $0.updateCell()
                         }


### PR DESCRIPTION
From time to time it is helpful to have non-selectable rows like switch rows besides selectable rows (e.g. as inline rows). While this basically works, it fails when the selected row changes. In this case, also the values of the non-selectable rows are reset. With a little check this can be fixed.