### PR TITLE
Disable iOS 11 section header/footer self-sizing

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -787,6 +787,14 @@ extension FormViewController : UITableViewDelegate {
         }
         return view.bounds.height
     }
+    
+    open func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return self.tableView(tableView, heightForHeaderInSection: section)
+    }
+    
+    open func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+        return self.tableView(tableView, heightForFooterInSection: section)
+    }
 
     open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard let section = form[indexPath.section] as? MultivaluedSection else { return false }


### PR DESCRIPTION
This fixes an iOS 11-specific issue where the table view would add space for section headers and footers, even if `tableView(_:viewForHeaderInSection:)` or `tableView(_:viewForFooterInSection:)` returned `nil`. This commit turns off self-sizing for section headers and footers, just like how we are already handling `tableView(_:estimatedHeightForRowAt:)`.

See [this Stack Overflow post](https://stackoverflow.com/a/46257601/1926015) for more info.

## Screenshot
![slice](https://user-images.githubusercontent.com/2835199/31017952-54cbaba8-a4f8-11e7-86ed-382676dfed67.png)
