### PR TITLE
Allow for FromViewController subclasses to display section indices

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -929,7 +929,7 @@ extension FormViewController : UITableViewDataSource {
         return nil
     }
     
-    public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
+    open func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
         return 0
     }
 }

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -924,6 +924,14 @@ extension FormViewController : UITableViewDataSource {
     open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return form[section].footer?.title
     }
+    
+    open func sectionIndexTitles(for tableView: UITableView) -> [String]? {
+        return nil
+    }
+    
+    public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
+        return 0
+    }
 }
 
 


### PR DESCRIPTION
I need to display section indices from a `SelectorViewController` subclass of mine, but since `FormViewController` doesn't have a default implementation for `sectionIndexTitles(for:)` and `tableView(_:, sectionForSectionIndexTitle:, at:)` my subclass's implementations are not called. This PR includes default implementations that do not affect the current behavior and don't attempt to display any section indices. 