### PR TITLE
Add workaround for UIDatePicker bug when mode == .countDownTimer

### DIFF
--- a/Source/Rows/DatePickerRow.swift
+++ b/Source/Rows/DatePickerRow.swift
@@ -74,6 +74,13 @@ open class DatePickerCell: Cell<Date>, CellType {
 
     @objc func datePickerValueChanged(_ sender: UIDatePicker) {
         row?.value = sender.date
+        
+        // workaround for UIDatePicker bug when it doesn't trigger "value changed" event after trying to pick 00:00 value
+        // for details see this comment: https://stackoverflow.com/questions/20181980/uidatepicker-bug-uicontroleventvaluechanged-after-hitting-minimum-internal#comment56681891_20204225
+        if sender.datePickerMode == .countDownTimer && sender.countDownDuration == TimeInterval(sender.minuteInterval * 60) {
+            datePicker.countDownDuration = sender.countDownDuration
+        }
+        
     }
 
     private func datePickerMode() -> UIDatePickerMode {


### PR DESCRIPTION
Hi! Found an issue in rows that use UIDatePicker with mode == .countDownTimer. 
Steps to reproduce:
1. Run Examples app
2. Inline rows -> CountDownInlineRow
3. Try to choose 0h0m. UIDatePicker will automatically choose 0h1m(because UIDatePicker doesn't allow to choose 00:00 interval)
4. Choose 1h1m. 
Actual result: label with row value remains on 0h1m value, but UIDatePicker shows 1h1m.
Expected result: both label and UIDatePicker must have 1h1m value.

It turned out that it is a old UIDatePicker bug. I've just added workaround suggested in this [StackOverflow thread](https://stackoverflow.com/questions/20181980/uidatepicker-bug-uicontroleventvaluechanged-after-hitting-minimum-internal#comment56681891_20204225) and everything is working now. 