### PR TITLE
Fix regular expression for URLs to allow query and location parameter

### DIFF
--- a/Source/Validations/RuleRegExp.swift
+++ b/Source/Validations/RuleRegExp.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public enum RegExprPattern: String {
     case EmailAddress = "^[_A-Za-z0-9-+]+(\\.[_A-Za-z0-9-+]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$"
-    case URL = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
+    case URL = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+([/?#]\\S*)?"
     case ContainsNumber = ".*\\d.*"
     case ContainsCapital = "^.*?[A-Z].*?$"
     case ContainsLowercase = "^.*?[a-z].*?$"

--- a/Tests/ValidationsTests.swift
+++ b/Tests/ValidationsTests.swift
@@ -142,4 +142,16 @@ class ValidationsTests: XCTestCase {
         XCTAssertNil(exactLengthRule.isValid(value: "123"))
         XCTAssertNotNil(exactLengthRule.isValid(value:"1234"))
     }
+    
+    func testRuleURL() {
+        let urlRule = RuleURL()
+        
+        XCTAssertNil(urlRule.isValid(value: nil))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "")))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "http://example.com")))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "https://example.com/path/to/file.ext?key=value#location")))
+        
+        XCTAssertNotNil(urlRule.isValid(value: URL(string: "example.com")))
+        XCTAssertNotNil(urlRule.isValid(value: URL(string: "http://")))
+    }
 }


### PR DESCRIPTION
I appended the regular expression pattern `([/?#]\\S*)?` to allow an optional query parameter (e.g. `?key=value&flag` and a location anchor (e.g. `#location`) at the end of the URL.

This also adds a basic test for the `RuleURL`.

Fixes #1239 

Note: The URL matcher could still be improved by using tested regular expressions like [these](https://mathiasbynens.be/demo/url-regex), but this seems to be science in itself.