### PR TITLE
Fix FieldCell titleLabel layout can overlap to its value label

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -403,6 +403,13 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
 	open override func layoutSubviews() {
 		super.layoutSubviews()
 		guard let row = (row as? FieldRowConformance) else { return }
+		defer {
+			// As titleLabel is the textLabel, iOS may re-layout without updating constraints, for example:
+			// swiping, showing alert or actionsheet from the same section.
+			// thus we need forcing update to use customConstraints()
+			setNeedsUpdateConstraints()
+			updateConstraintsIfNeeded()
+		}
 		guard let titlePercentage = row.titlePercentage else  { return }
 		var targetTitleWidth = bounds.size.width * titlePercentage
 		if let imageView = imageView, let _ = imageView.image, let titleLabel = titleLabel {
@@ -414,11 +421,6 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
 			}
 			targetTitleWidth -= extraWidthToSubtract
 		}
-		let targetTitlePercentage = targetTitleWidth / contentView.bounds.size.width
-		if calculatedTitlePercentage != targetTitlePercentage {
-			calculatedTitlePercentage = targetTitlePercentage
-			setNeedsUpdateConstraints()
-			updateConstraintsIfNeeded()
-		}
+		calculatedTitlePercentage = targetTitleWidth / contentView.bounds.size.width
 	}
 }


### PR DESCRIPTION
In addition to #965 ...

I found that the force updating constraints introduced in #965 is useful also when `titlePercentage` is not customized.

Without forcing that, title label can overlap to its value label.
The issue reproduces when iOS perform re-layout titleLabel (with the fact that titleLabel refs to `UITableViewCell.textLabel`) without updating its constraints. This case may occur in swiping, showing alert or actionsheet from the same section.

In the Eureka Example, adding ActionSheetRow after TextRow and set a long title for the TextRow reproduce the issue on iOS 11 (including iOS 11.2).

![screen shot 2017-12-07 at 11 28 42](https://user-images.githubusercontent.com/11156/33696064-cfb99b14-db43-11e7-8f24-502b31651dc8.png)

![screen shot 2017-12-07 at 11 28 46](https://user-images.githubusercontent.com/11156/33696066-d164dd5c-db43-11e7-8709-6d10f7526381.png)