### PR TITLE
Crash prevent Section.swift

### DIFF
--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -44,7 +44,7 @@ extension Section : Hidable, SectionDelegate {}
 extension Section {
 
     public func reload(with rowAnimation: UITableViewRowAnimation = .none) {
-        guard let tableView = (form?.delegate as? FormViewController)?.tableView, let index = index else { return }
+        guard let tableView = (form?.delegate as? FormViewController)?.tableView, let index = index, index < tableView.numberOfSections else { return }
         tableView.reloadSections(IndexSet(integer: index), with: rowAnimation)
     }
 }


### PR DESCRIPTION
It's crashing when 'index' is greater than number of sections of tableView.

