### PR TITLE
fixed: NSForegroundColorAttributeName syntax changed to use in swift 3+

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -230,7 +230,7 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
         textField.font = .preferredFont(forTextStyle: .body)
         if let placeholder = (row as? FieldRowConformance)?.placeholder {
             if let color = (row as? FieldRowConformance)?.placeholderColor {
-                textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedStringKey.foregroundColor: color])
+                textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSForegroundColorAttributeName: color])
             } else {
                 textField.placeholder = (row as? FieldRowConformance)?.placeholder
             }


### PR DESCRIPTION
Single line modified to avoid swift 3 compilations errors

NSAttributedStringKey.foregroundColor is changed for NSForegroundColorAttributeName