### PR TITLE
Setup alert controller cancel title from row

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		51729DF61B9A4F5E004A00EB /* Eureka.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51729DEB1B9A4F5E004A00EB /* Eureka.framework */; };
 		51729E671B9A5FA5004A00EB /* Eureka.h in Headers */ = {isa = PBXBuildFile; fileRef = 51729E661B9A5FA5004A00EB /* Eureka.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8690E4BE1CFDE062004CDB1C /* Eureka.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8690E4BD1CFDE062004CDB1C /* Eureka.bundle */; };
+		B244E6541FE1C94F0026B944 /* AlertOptionsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B244E6531FE1C94F0026B944 /* AlertOptionsRow.swift */; };
 		B257FE2E1EC0F66900043911 /* RowsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */; };
 		B2A401161EC0BA140042EDF0 /* SectionsInsertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */; };
 		FA56B6AF1DBAD38900407C94 /* RuleEqualsToRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA56B6AE1DBAD38900407C94 /* RuleEqualsToRow.swift */; };
@@ -180,6 +181,7 @@
 		51729DFC1B9A4F5E004A00EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		51729E661B9A5FA5004A00EB /* Eureka.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Eureka.h; path = Source/Eureka.h; sourceTree = SOURCE_ROOT; };
 		8690E4BD1CFDE062004CDB1C /* Eureka.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Eureka.bundle; sourceTree = "<group>"; };
+		B244E6531FE1C94F0026B944 /* AlertOptionsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AlertOptionsRow.swift; path = Common/AlertOptionsRow.swift; sourceTree = "<group>"; };
 		B257FE2D1EC0F66900043911 /* RowsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RowsInsertionTests.swift; path = Tests/RowsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
 		B2A401151EC0BA140042EDF0 /* SectionsInsertionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SectionsInsertionTests.swift; path = Tests/SectionsInsertionTests.swift; sourceTree = SOURCE_ROOT; };
 		FA56B6AE1DBAD38900407C94 /* RuleEqualsToRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RuleEqualsToRow.swift; path = Source/Validations/RuleEqualsToRow.swift; sourceTree = SOURCE_ROOT; };
@@ -268,6 +270,7 @@
 			children = (
 				2859CDF01C7DF1620002982F /* FieldRow.swift */,
 				2859CDB31C7D0E4B0002982F /* OptionsRow.swift */,
+				B244E6531FE1C94F0026B944 /* AlertOptionsRow.swift */,
 				2859CDBB1C7D12930002982F /* SelectorRow.swift */,
 				2859CDEE1C7DF0F70002982F /* DateFieldRow.swift */,
 				2859CDF21C7DF22D0002982F /* DateInlineFieldRow.swift */,
@@ -528,6 +531,7 @@
 				28EEC0101C7E399500300699 /* DateInlineFieldRow.swift in Sources */,
 				2859CDC61C7D1A2E0002982F /* NavigationAccessoryView.swift in Sources */,
 				49ADC7F91C8A83240073952B /* StepperRow.swift in Sources */,
+				B244E6541FE1C94F0026B944 /* AlertOptionsRow.swift in Sources */,
 				28EE46AC1C7F712300EFF4A2 /* DateInlineRow.swift in Sources */,
 				28EEC01C1C7E3A7400300699 /* ButtonRowWithPresent.swift in Sources */,
 				28EEBFF41C7E240000300699 /* RowProtocols.swift in Sources */,

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -224,6 +224,7 @@ class RowsExampleViewController: FormViewController {
             
                 <<< AlertRow<Emoji>() {
                         $0.title = "AlertRow"
+                        $0.cancelTitle = "Dismiss"
                         $0.selectorTitle = "Who is there?"
                         $0.options = [💁🏻, 🍐, 👦🏼, 🐗, 🐼, 🐻]
                         $0.value = 👦🏼

--- a/Source/Rows/ActionSheetRow.swift
+++ b/Source/Rows/ActionSheetRow.swift
@@ -47,7 +47,7 @@ open class AlertSelectorCell<T> : Cell<T>, CellType where T: Equatable {
     }
 }
 
-public class _ActionSheetRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
+public class _ActionSheetRow<Cell: CellType>: AlertOptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
 
     public typealias ProviderType = SelectorAlertController<_ActionSheetRow<Cell>>
     

--- a/Source/Rows/AlertRow.swift
+++ b/Source/Rows/AlertRow.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 
-open class _AlertRow<Cell: CellType>: OptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
+open class _AlertRow<Cell: CellType>: AlertOptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
 
     public typealias PresentedController = SelectorAlertController<_AlertRow<Cell>>
     

--- a/Source/Rows/Common/AlertOptionsRow.swift
+++ b/Source/Rows/Common/AlertOptionsRow.swift
@@ -1,4 +1,5 @@
-//  OptionsRow.swift
+//
+//  AlertOptionsRow.swift
 //  Eureka ( https://github.com/xmartlabs/Eureka )
 //
 //  Copyright (c) 2016 Xmartlabs SRL ( http://xmartlabs.com )
@@ -24,14 +25,17 @@
 
 import Foundation
 
-open class OptionsRow<Cell: CellType> : Row<Cell>, NoValueDisplayTextConformance, OptionsProviderRow where Cell: BaseCell {
-    
-    open var optionsProvider: OptionsProvider<Cell.Value>?
-    
-    open var selectorTitle: String?
-    open var noValueDisplayText: String?
+
+import Foundation
+
+open class AlertOptionsRow<Cell: CellType> : OptionsRow<Cell>, AlertOptionsProviderRow where Cell: BaseCell {
+
+    typealias OptionsProviderType = OptionsProvider<Cell.Value>
+
+    open var cancelTitle: String?
 
     required public init(tag: String?) {
         super.init(tag: tag)
     }
+
 }

--- a/Source/Rows/Controllers/SelectorAlertController.swift
+++ b/Source/Rows/Controllers/SelectorAlertController.swift
@@ -24,12 +24,20 @@
 
 import Foundation
 
+/// Specific type, Responsible for the options passed to a selector alert view controller
+public protocol AlertOptionsProviderRow: OptionsProviderRow {
+
+    var cancelTitle: String? { get set }
+
+}
+
 /// Selector UIAlertController
-open class SelectorAlertController<OptionsRow: OptionsProviderRow>: UIAlertController, TypedRowControllerType where OptionsRow.OptionsProviderType.Option == OptionsRow.Cell.Value, OptionsRow: BaseRow {
+open class SelectorAlertController<AlertOptionsRow: AlertOptionsProviderRow>: UIAlertController, TypedRowControllerType where AlertOptionsRow.OptionsProviderType.Option == AlertOptionsRow.Cell.Value, AlertOptionsRow: BaseRow {
 
     /// The row that pushed or presented this controller
-    public var row: RowOf<OptionsRow.Cell.Value>!
+    public var row: RowOf<AlertOptionsRow.Cell.Value>!
 
+    @available(*, deprecated, message: "Use AlertOptionsRow.cancelTitle instead.")
     public var cancelTitle = NSLocalizedString("Cancel", comment: "")
 
     /// A closure to be called when the controller disappears.
@@ -38,8 +46,8 @@ open class SelectorAlertController<OptionsRow: OptionsProviderRow>: UIAlertContr
     /// Options provider to use to get available options.
     /// If not set will use synchronous data provider built with `row.dataProvider.arrayData`.
     //    public var optionsProvider: OptionsProvider<T>?
-    public var optionsProviderRow: OptionsRow {
-        return row as! OptionsRow
+    public var optionsProviderRow: AlertOptionsRow {
+        return row as! AlertOptionsRow
     }
 
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -58,12 +66,13 @@ open class SelectorAlertController<OptionsRow: OptionsProviderRow>: UIAlertContr
     open override func viewDidLoad() {
         super.viewDidLoad()
         guard let options = optionsProviderRow.options else { return }
+        let cancelTitle = optionsProviderRow.cancelTitle ?? self.cancelTitle
         addAction(UIAlertAction(title: cancelTitle, style: .cancel, handler: nil))
         for option in options {
             addAction(UIAlertAction(title: row.displayValueFor?(option), style: .default, handler: { [weak self] _ in
                 self?.row.value = option
                 self?.onDismissCallback?(self!)
-                }))
+            }))
         }
     }
 


### PR DESCRIPTION
# Fixes
These changes fixes the issue #1335 where changing the `SelectorAlertController.cancelTitle`'s value in some cases doesn't work because its value is used in the view did load callback.

# Changes
* Add a new row type `AlertOptionsRow` used specifically for option rows that show an `UIAlertController`.
* `AlertOptionsRow` includes the property `cancelTitle` in order to change the cancel action's title within `UIActionController`.
* Deprecates `SelectorAlertController.cancelTitle` in favor of `AlertOptionsRow.cancelTitle`