### PR TITLE
Add option formatter for SelectorRow

### DIFF
--- a/Source/Rows/Common/GenericMultipleSelectorRow.swift
+++ b/Source/Rows/Common/GenericMultipleSelectorRow.swift
@@ -33,6 +33,11 @@ open class GenericMultipleSelectorRow<T, Cell: CellType>: Row<Cell>, PresenterRo
     /// Defines how the view controller will be presented, pushed, etc.
     open var presentationMode: PresentationMode<PresentedController>?
 
+    /// Block variable used to get the String that should be displayed for option rows.
+    open var optionFormatter: ((T) -> String?) = {
+        return String(describing: $0)
+    }
+    
     /// Will be called before the presentation occurs.
     open var onPresentCallback: ((FormViewController, PresentedController) -> Void)?
 

--- a/Source/Rows/Common/OptionsRow.swift
+++ b/Source/Rows/Common/OptionsRow.swift
@@ -30,7 +30,11 @@ open class OptionsRow<Cell: CellType> : Row<Cell>, NoValueDisplayTextConformance
     
     open var selectorTitle: String?
     open var noValueDisplayText: String?
-
+    /// Block variable used to get the String that should be displayed for option rows.
+    open var optionFormatter: ((Cell.Value) -> String?) = {
+        return String(describing: $0)
+    }
+    
     required public init(tag: String?) {
         super.init(tag: tag)
     }

--- a/Source/Rows/Controllers/MultipleSelectorViewController.swift
+++ b/Source/Rows/Controllers/MultipleSelectorViewController.swift
@@ -120,7 +120,7 @@ open class _MultipleSelectorViewController<Row: SelectableRowType, OptionsRow: O
         }
         for option in options {
             section <<< Row.init { lrow in
-                lrow.title = String(describing: option)
+                lrow.title = (self.row as? OptionsRow)?.optionFormatter(option)
                 lrow.selectableValue = option
                 lrow.value = self.row.value?.contains(option) ?? false ? option : nil
             }.cellSetup { [weak self] cell, row in

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -35,6 +35,9 @@ public protocol OptionsProviderRow: TypedRowType {
     var optionsProvider: OptionsProviderType? { get set }
     
     var cachedOptionsData: [OptionsProviderType.Option]? { get set }
+    
+    /// Block variable used to get the String that should be displayed for option rows.
+    var optionFormatter: ((OptionsProviderType.Option) -> String?) { get set }
 }
 
 extension OptionsProviderRow where Self: BaseRow {
@@ -213,7 +216,7 @@ open class _SelectorViewController<Row: SelectableRowType, OptionsRow: OptionsPr
         }
         for option in options {
             section <<< Row.init(String(describing: option)) { lrow in
-                lrow.title = self.row.displayValueFor?(option)
+                lrow.title = (self.row as? OptionsRow)?.optionFormatter(option)
                 lrow.selectableValue = option
                 lrow.value = self.row.value == option ? option : nil
             }.cellSetup { [weak self] cell, row in


### PR DESCRIPTION
Add option formatter for Single/Multi Options Row:

**Usage:**
```
let medication = MultipleSelectorRow<Medication> {
            $0.options = [medications]
            $0.optionFormatter = { medication in
                return medication.name
            }
        }
```

<img width="412" alt="screen shot 2017-12-29 at 2 19 04 pm" src="https://user-images.githubusercontent.com/6436310/34431645-652e5624-eca3-11e7-879c-008389bf1ed1.png">
