### PR TITLE
Prepend section(s) to form

### DIFF
--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -212,6 +212,22 @@ extension Form : RangeReplaceableCollection {
             section.wasAddedTo(form: self)
         }
     }
+    
+    public func prepend(_ formSection: Section) {
+        kvoWrapper.sections.insert(formSection, at: 0)
+        kvoWrapper._allSections.insert(formSection, at: 0)
+        formSection.wasAddedTo(form: self)
+    }
+    
+    public func prepend<S: Sequence>(contentsOf newElements: S) where S.Iterator.Element == Section {
+        let newElementsArr: [S.Iterator.Element] = newElements.map { $0 }
+        let indexSet: IndexSet = IndexSet(integersIn: 0..<newElementsArr.count)
+        kvoWrapper.sections.insert(newElementsArr, at: indexSet)
+        kvoWrapper._allSections.insert(contentsOf: newElementsArr, at: 0)
+        for section in newElements {
+            section.wasAddedTo(form: self)
+        }
+    }
 
     public func replaceSubrange<C: Collection>(_ subRange: Range<Int>, with newElements: C) where C.Iterator.Element == Section {
         for i in subRange.lowerBound..<subRange.upperBound {

--- a/Tests/SectionsInsertionTests.swift
+++ b/Tests/SectionsInsertionTests.swift
@@ -37,6 +37,34 @@ class SectionInsertionTests: XCTestCase {
             expectedTitles: ["section_01", "section_02", "section_03"]
         )
     }
+    
+    func testPrependingSections() {
+        let form = Form()
+            +++ Section("section_01")
+        
+        form.prepend(Section("section_02"))
+        form.prepend(Section("section_03"))
+        
+        hideAndShowSections(
+            form: form,
+            expectedTitles: ["section_03", "section_02", "section_01"]
+        )
+    }
+    
+    func testPrependingSectionSequence() {
+        let form = Form()
+            +++ Section("section_01")
+        
+        form.prepend(contentsOf: [
+            Section("section_02"),
+            Section("section_03"),
+        ])
+        
+        hideAndShowSections(
+            form: form,
+            expectedTitles: ["section_02", "section_03", "section_01"]
+        )
+    }
 
     func testInsertingSectionsWithSubscript() {
         let form = Form()


### PR DESCRIPTION
Helper functions to prepend a section or collection of sections to the beginning of the form.