### PR TITLE
Update cell when tintColor changes

### DIFF
--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -150,6 +150,12 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
         return result
     }
 
+    open override func tintColorDidChange() {
+        super.tintColorDidChange()
+
+        row.updateCell()
+    }
+
     /// The untyped row associated to this cell.
     public override var baseRow: BaseRow! { return row }
 }


### PR DESCRIPTION
So the textColor can be updated if it uses the tintColor, which a lot of cells do. It appears that the tintColor is currently used before the cell is added to the window, so if the tintColor has been customised on the window the cells aren’t updated.

Calling row.updateCell() seems like the best thing to call, as that should encompass all code (built-in and custom) that uses the tintColor.

