### PR TITLE
Update CustomCells.swift

### DIFF
--- a/Example/Example/CustomCells.swift
+++ b/Example/Example/CustomCells.swift
@@ -405,6 +405,8 @@ public class URLFloatLabelCell : _FloatLabelCell<URL>, CellType {
 
     public override func setup() {
         super.setup()
+        textField?.autocorrectionType = .no
+        textField?.autocapitalizationType = .none
         textField?.keyboardType = .URL
     }
 }
@@ -502,6 +504,12 @@ public final class EmailFloatLabelRow: FloatFieldRow<EmailFloatLabelCell>, RowTy
         super.init(tag: tag)
     }
 }
+public final class PhoneFloatLabelRow: FloatFieldRow<PhoneFloatLabelCell>, RowType {
+    public required init(tag: String?) {
+        super.init(tag: tag)
+    }
+}
+
 
 //MARK: LocationRow
 


### PR DESCRIPTION
URLFloatLabelCell Updates:
- Set autocapitalization to none. This prevents the error where the user types a URL and it starts with a capital "W," such as "Www.github.com".
- Set autocorrection to no. This prevents the keyboard from correcting spellings, such as adding a space in "business week.com".

Added PhoneFloatLabelRow. In the list of these specialized rows, this type of a row was missing. However, the specialized Phone Cell existed, so it made sense to have this row also.

