### PR TITLE
allow ActionSheetRow to be subclassed

### DIFF
--- a/Source/Rows/ActionSheetRow.swift
+++ b/Source/Rows/ActionSheetRow.swift
@@ -47,7 +47,7 @@ open class AlertSelectorCell<T> : Cell<T>, CellType where T: Equatable {
     }
 }
 
-public class _ActionSheetRow<Cell: CellType>: AlertOptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
+open class _ActionSheetRow<Cell: CellType>: AlertOptionsRow<Cell>, PresenterRowType where Cell: BaseCell {
 
     public typealias ProviderType = SelectorAlertController<_ActionSheetRow<Cell>>
     
@@ -73,7 +73,7 @@ public class _ActionSheetRow<Cell: CellType>: AlertOptionsRow<Cell>, PresenterRo
         super.init(tag: tag)
     }
 
-    public override func customDidSelect() {
+    open override func customDidSelect() {
         super.customDidSelect()
         if let presentationMode = presentationMode, !isDisabled {
             if let controller = presentationMode.makeController() {


### PR DESCRIPTION
This is a really convenient place to subclass this row if you just want a custom UI, are we able to make it open please?

