### PR TITLE
CompletionHandler for SwipeAction under iOS < 11

### DIFF
--- a/Source/Core/SwipeActions.swift
+++ b/Source/Core/SwipeActions.swift
@@ -34,7 +34,15 @@ public class SwipeAction: ContextualAction {
         } else {
             action = UITableViewRowAction(style: style.contextualStyle as! UITableViewRowActionStyle,title: title){ [weak self] (action, indexPath) -> Void in
                 guard let strongSelf = self else{ return }
-                strongSelf.handler(strongSelf, forRow, nil)
+				strongSelf.handler(strongSelf, forRow) { _ in
+					DispatchQueue.main.async {
+						guard action.style == .destructive else {
+							forRow.baseCell?.formViewController()?.tableView?.setEditing(false, animated: true)
+							return
+						}
+						forRow.section?.remove(at: indexPath.row)
+					}
+				}
             }
         }
         action.backgroundColor = self.backgroundColor ?? action.backgroundColor


### PR DESCRIPTION
We have to end the SwipeActions manually sice iOS 10 does not automatically handle this for us.

This fixes #1457.