### PR TITLE
Implement readOnly textAreaRow feature

### DIFF
--- a/Example/Example/Controllers/FieldRowCustomizationController.swift
+++ b/Example/Example/Controllers/FieldRowCustomizationController.swift
@@ -80,6 +80,11 @@ class FieldRowCustomizationController : FormViewController {
                 $0.placeholder = "TextAreaRow"
                 $0.textAreaHeight = .dynamic(initialTextViewHeight: 110)
         }
+            <<< TextAreaRow() {
+                $0.value = "You also have scrollable read only textAreaRows! I have to write a big text so you will be able to scroll a lot and see that this row is scrollable. I think it is a good idea to insert a Lorem Ipsum here: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ac odio consectetur, faucibus elit at, congue dolor. Duis quis magna eu ante egestas laoreet. Vivamus ultricies tristique porttitor. Proin viverra sem non turpis molestie, volutpat facilisis justo rutrum. Nulla eget commodo ligula. Aliquam lobortis lobortis justo id fermentum. Sed sit amet elit eu ipsum ultricies porttitor et sed justo. Fusce id mi aliquam, iaculis odio ac, tempus sem. Aenean in eros imperdiet, euismod lacus vitae, mattis nulla. Praesent ornare sem vitae ornare efficitur. Nullam dictum tortor a tortor vestibulum pharetra. Donec sollicitudin varius fringilla. Praesent posuere fringilla tristique. Aliquam dapibus vel nisi in sollicitudin. In eu ligula arcu."
+                $0.textAreaMode = .readOnly
+                $0.textAreaHeight = .fixed(cellHeight: 110)
+        }
 
     }
 }

--- a/Source/Rows/TextAreaRow.swift
+++ b/Source/Rows/TextAreaRow.swift
@@ -1,4 +1,4 @@
-//  AlertRow.swift
+//  TextAreaRow.swift
 //  Eureka ( https://github.com/xmartlabs/Eureka )
 //
 //  Copyright (c) 2016 Xmartlabs SRL ( http://xmartlabs.com )
@@ -27,6 +27,11 @@ import Foundation
 public enum TextAreaHeight {
     case fixed(cellHeight: CGFloat)
     case dynamic(initialTextViewHeight: CGFloat)
+}
+
+public enum TextAreaMode {
+    case normal
+    case readOnly
 }
 
 protocol TextAreaConformance: FormatterConformance {
@@ -226,6 +231,9 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
     }
 
     open func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        if let textAreaRow = self.row as? TextAreaRow, textAreaRow.textAreaMode == .readOnly {
+            return false
+        }
         return formViewController()?.textInputShouldBeginEditing(textView, cell: self) ?? true
     }
 
@@ -278,7 +286,8 @@ open class AreaRow<Cell: CellType>: FormatteableRow<Cell>, TextAreaConformance w
 
     open var placeholder: String?
     open var textAreaHeight = TextAreaHeight.fixed(cellHeight: 110)
-
+    open var textAreaMode = TextAreaMode.normal
+    
     public required init(tag: String?) {
         super.init(tag: tag)
     }

--- a/Source/Rows/TextAreaRow.swift
+++ b/Source/Rows/TextAreaRow.swift
@@ -231,7 +231,7 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
     }
 
     open func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        if let textAreaRow = self.row as? TextAreaRow, textAreaRow.textAreaMode == .readOnly {
+        if let textAreaRow = self.row as? _TextAreaRow, textAreaRow.textAreaMode == .readOnly {
             return false
         }
         return formViewController()?.textInputShouldBeginEditing(textView, cell: self) ?? true


### PR DESCRIPTION
Based on this [issue](https://github.com/xmartlabs/Eureka/issues/41) I added the possibility for a scrollable read only textAreaRow. I also changed the Example app to show its implementation. Hope it helps!