### PR TITLE
Update cell when tintColor changes (without crashing)

### DIFF
--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -92,6 +92,8 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
     /// The row associated to this cell
     public weak var row: RowOf<T>!
 
+    private var updating = false
+
     /// Returns the navigationAccessoryView if it is defined or calls super if not.
     override open var inputAccessoryView: UIView? {
         if let v = formViewController()?.inputAccessoryView(for: row) {
@@ -119,10 +121,14 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
      Function responsible for updating the cell each time it is reloaded.
      */
     open override func update() {
+        updating = true
+
         super.update()
         textLabel?.text = row.title
         textLabel?.textColor = row.isDisabled ? .gray : .black
         detailTextLabel?.text = row.displayValueFor?(row.value) ?? (row as? NoValueDisplayTextConformance)?.noValueDisplayText
+
+        updating = false
     }
 
     /**
@@ -153,7 +159,10 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
     open override func tintColorDidChange() {
         super.tintColorDidChange()
 
-        row.updateCell()
+        /* Protection from infinite recursion in case an update method changes the tintColor */
+        if !updating {
+            row.updateCell()
+        }
     }
 
     /// The untyped row associated to this cell.

--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -150,6 +150,12 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
         return result
     }
 
+    open override func tintColorDidChange() {
+        super.tintColorDidChange()
+
+        row.updateCell()
+    }
+
     /// The untyped row associated to this cell.
     public override var baseRow: BaseRow! { return row }
 }

--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -92,7 +92,7 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
     /// The row associated to this cell
     public weak var row: RowOf<T>!
 
-    private var updating = false
+    private var updatingCellForTintColorDidChange = false
 
     /// Returns the navigationAccessoryView if it is defined or calls super if not.
     override open var inputAccessoryView: UIView? {
@@ -121,14 +121,10 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
      Function responsible for updating the cell each time it is reloaded.
      */
     open override func update() {
-        updating = true
-
         super.update()
         textLabel?.text = row.title
         textLabel?.textColor = row.isDisabled ? .gray : .black
         detailTextLabel?.text = row.displayValueFor?(row.value) ?? (row as? NoValueDisplayTextConformance)?.noValueDisplayText
-
-        updating = false
     }
 
     /**
@@ -160,8 +156,10 @@ open class Cell<T>: BaseCell, TypedCellType where T: Equatable {
         super.tintColorDidChange()
 
         /* Protection from infinite recursion in case an update method changes the tintColor */
-        if !updating {
+        if !updatingCellForTintColorDidChange {
+            updatingCellForTintColorDidChange = true
             row.updateCell()
+            updatingCellForTintColorDidChange = false
         }
     }
 

--- a/Source/Rows/ButtonRow.swift
+++ b/Source/Rows/ButtonRow.swift
@@ -42,8 +42,7 @@ open class ButtonCellOf<T: Equatable>: Cell<T>, CellType {
         accessoryType = .none
         editingAccessoryType = accessoryType
         textLabel?.textAlignment = .center
-        textLabel?.textColor = tintColor
-        textLabel?.textColor  = tintColor.withAlphaComponent(row.isDisabled ? 0.3 : 1.0)
+        textLabel?.textColor = tintColor.withAlphaComponent(row.isDisabled ? 0.3 : 1.0)
     }
 
     open override func didSelect() {

--- a/Source/Rows/CheckRow.swift
+++ b/Source/Rows/CheckRow.swift
@@ -41,13 +41,11 @@ public final class CheckCell: Cell<Bool>, CellType {
         accessoryType = row.value == true ? .checkmark : .none
         editingAccessoryType = accessoryType
         selectionStyle = .default
-        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        tintColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         if row.isDisabled {
-            tintColor = UIColor(red: red, green: green, blue: blue, alpha: 0.3)
+            tintAdjustmentMode = .dimmed
             selectionStyle = .none
         } else {
-            tintColor = UIColor(red: red, green: green, blue: blue, alpha: 1)
+            tintAdjustmentMode = .automatic
         }
     }
 

--- a/Source/Rows/SelectableRows/ListCheckRow.swift
+++ b/Source/Rows/SelectableRows/ListCheckRow.swift
@@ -39,13 +39,11 @@ open class ListCheckCell<T: Equatable> : Cell<T>, CellType {
         accessoryType = row.value != nil ? .checkmark : .none
         editingAccessoryType = accessoryType
         selectionStyle = .default
-        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-        tintColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         if row.isDisabled {
-            tintColor = UIColor(red: red, green: green, blue: blue, alpha: 0.3)
+            tintAdjustmentMode = .dimmed
             selectionStyle = .none
         } else {
-            tintColor = UIColor(red: red, green: green, blue: blue, alpha: 1)
+            tintAdjustmentMode = .automatic
         }
     }
 

--- a/Source/Rows/StepperRow.swift
+++ b/Source/Rows/StepperRow.swift
@@ -44,7 +44,6 @@ open class StepperCell: Cell<Double>, CellType {
         selectionStyle = .none
 
         stepper.addTarget(self, action: #selector(StepperCell.valueChanged), for: .valueChanged)
-        valueLabel?.textColor = stepper.tintColor
     }
 
     deinit {
@@ -56,6 +55,7 @@ open class StepperCell: Cell<Double>, CellType {
         stepper.isEnabled = !row.isDisabled
         stepper.value = row.value ?? 0
         stepper.alpha = row.isDisabled ? 0.3 : 1.0
+        valueLabel?.textColor = tintColor
         valueLabel?.alpha = row.isDisabled ? 0.3 : 1.0
         valueLabel?.text = row.displayValueFor?(row.value)
         detailTextLabel?.text = nil


### PR DESCRIPTION
This is a do-over of #1439, which caused crashes reported #1447.

As in #1439 we update the row when the tint colour changes. This should capture all uses of `tintColor` in the various `update` methods throughout the framework.

This PR adds explicit detection of the potential for an infinite loop, which occurs when a cell changes its `tintColor` in the `update` method. This change is in `Cell.swift`.

This PR also removes all the instances where components _change_ the `tintColor` in their `update` method. I don't believe that our cells _should_ set their own `tintColor` as this prevents them from participating in the cascade of `tintColor` from their parent views. In `CheckRow.swift` and `ListCheckRow.swift` I have changed to using `tintAdjustmentMode`, which I believe is the correct way to achieve what those cells are trying to achieve. Note that there are many other cells in the project that use `tintColor` dimmed to 30% alpha to indicate a disabled state. This is not what the `tintAdjustmentMode` does; I believe instead it sets them to grey, but who knows what else it might do. It may be a separate task to make other components match up to the behaviour of `tintAdjustmentMode`—I feel like it's best to match that, as it's Apple's way ;-)

This PR also corrects the `tintColor` behaviour of `StepperRow`.

You can easily test the `tintColor` behaviour by setting the `tintColor` on the `view` in the example app view controllers, such as `RowsExampleViewController`. If you do that before and after this PR you should see what this PR is fixing!