### PR TITLE
add 'selectableRowSetup' callback to SelectorViewController & MultipleSelectorViewController

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		8F325067205AAD7A006AF0A6 /* MultivaluedExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F325066205AAD7A006AF0A6 /* MultivaluedExamples.swift */; };
 		8F325069205AAF1E006AF0A6 /* SwipeActionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F325068205AAF1E006AF0A6 /* SwipeActionsController.swift */; };
 		8F32506B205AAF66006AF0A6 /* PlainTableViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F32506A205AAF66006AF0A6 /* PlainTableViewExample.swift */; };
+		D4ACF9132074B52200AEA952 /* EmojiCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D4ACF9122074B52200AEA952 /* EmojiCell.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +132,7 @@
 		8F325066205AAD7A006AF0A6 /* MultivaluedExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultivaluedExamples.swift; sourceTree = "<group>"; };
 		8F325068205AAF1E006AF0A6 /* SwipeActionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActionsController.swift; sourceTree = "<group>"; };
 		8F32506A205AAF66006AF0A6 /* PlainTableViewExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTableViewExample.swift; sourceTree = "<group>"; };
+		D4ACF9122074B52200AEA952 /* EmojiCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmojiCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -259,6 +261,7 @@
 				287A143B1D99A91B00FFE6EB /* ImageRow */,
 				2837E29D1BA3A5A800A1952C /* Helpers */,
 				51729E6F1B9A660A004A00EB /* WeekDaysCell.xib */,
+				D4ACF9122074B52200AEA952 /* EmojiCell.xib */,
 				51729E6D1B9A6601004A00EB /* CustomCells.swift */,
 			);
 			name = "Custom Row and Cell";
@@ -404,6 +407,7 @@
 				284D28B61E49121E00BB38E7 /* DatePickerCell.xib in Resources */,
 				28CD97C21BB32F0E00AFDA67 /* EurekaSectionHeader.xib in Resources */,
 				51729E231B9A54F1004A00EB /* Main.storyboard in Resources */,
+				D4ACF9132074B52200AEA952 /* EmojiCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/EmojiCell.xib
+++ b/Example/EmojiCell.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14092" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14081.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="EmojiCell" textLabel="4Kb-XA-Gei" detailTextLabel="b0T-tu-awZ" rowHeight="87" style="IBUITableViewCellStyleSubtitle" id="IUS-Ee-0Ac" customClass="EmojiCell" customModule="Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="87"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IUS-Ee-0Ac" id="Qbf-AF-gzT">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="86.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="💁🏻" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Kb-XA-Gei">
+                        <rect key="frame" x="16" y="15" width="40" height="42"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="b0T-tu-awZ">
+                        <rect key="frame" x="16" y="57" width="44" height="14.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="46.5" y="15.5"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Example/Example/Controllers/RowsExample.swift
+++ b/Example/Example/Controllers/RowsExample.swift
@@ -164,6 +164,28 @@ class RowsExampleViewController: FormViewController {
                     }
         }
 
+            <<< PushRow<Emoji>() {
+                $0.title = "Custom Cell Push Row"
+                $0.options = [💁🏻, 🍐, 👦🏼, 🐗, 🐼, 🐻]
+                $0.value = 👦🏼
+                $0.selectorTitle = "Choose an Emoji!"
+                }
+                .onPresent { from, to in
+                    to.selectableRowSetup = { row in
+                        row.cellProvider = CellProvider<ListCheckCell<Emoji>>(nibName: "EmojiCell", bundle: Bundle.main)
+                    }
+                    to.selectableRowCellUpdate = { cell, row in
+                        var detailText: String?
+                        switch row.selectableValue {
+                        case 💁🏻, 👦🏼: detailText = "Person"
+                        case 🐗, 🐼, 🐻: detailText = "Animal"
+                        case 🍐: detailText = "Food"
+                        default: detailText = ""
+                        }
+                        cell.detailTextLabel?.text = detailText
+                    }
+        }
+
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             let section = form.last!

--- a/Example/Example/CustomCells.swift
+++ b/Example/Example/CustomCells.swift
@@ -757,3 +757,5 @@ public class ImageCheckCell<T: Equatable> : Cell<T>, CellType {
     }
 
 }
+
+class EmojiCell: ListCheckCell<Emoji> {}

--- a/README.md
+++ b/README.md
@@ -1086,7 +1086,7 @@ section.reload()
 
 #### How to customize Selector and MultipleSelector option cells
 
-`selectableRowCellUpdate` and `selectableRowCellSetup` properties are provided to be able to customize SelectorViewController and MultipleSelectorViewController selectable cells.
+`selectableRowSetup`, `selectableRowCellUpdate` and `selectableRowCellSetup` properties are provided to be able to customize SelectorViewController and MultipleSelectorViewController selectable cells.
 
 ```swift
 let row = PushRow<Emoji>() {
@@ -1097,6 +1097,9 @@ let row = PushRow<Emoji>() {
           }.onPresent { from, to in
               to.dismissOnSelection = false
               to.dismissOnChange = false
+              to.selectableRowSetup = { row in
+                  row.cellProvider = CellProvider<ListCheckCell<Emoji>>(nibName: "EmojiCell", bundle: Bundle.main)
+              }
               to.selectableRowCellUpdate = { cell, row in
                   cell.textLabel?.text = "Text " + row.selectableValue!  // customization
                   cell.detailTextLabel?.text = "Detail " +  row.selectableValue!

--- a/Source/Rows/Controllers/MultipleSelectorViewController.swift
+++ b/Source/Rows/Controllers/MultipleSelectorViewController.swift
@@ -30,9 +30,10 @@ open class _MultipleSelectorViewController<Row: SelectableRowType, OptionsRow: O
     /// The row that pushed or presented this controller
     public var row: RowOf<Set<OptionsRow.OptionsProviderType.Option>>!
 
+    public var selectableRowSetup: ((_ row: Row) -> Void)?
     public var selectableRowCellSetup: ((_ cell: Row.Cell, _ row: Row) -> Void)?
     public var selectableRowCellUpdate: ((_ cell: Row.Cell, _ row: Row) -> Void)?
-
+    
     /// A closure to be called when the controller disappears.
     public var onDismissCallback: ((UIViewController) -> Void)?
 
@@ -123,6 +124,7 @@ open class _MultipleSelectorViewController<Row: SelectableRowType, OptionsRow: O
                 lrow.title = String(describing: option)
                 lrow.selectableValue = option
                 lrow.value = self.row.value?.contains(option) ?? false ? option : nil
+                self.selectableRowSetup?(lrow)
             }.cellSetup { [weak self] cell, row in
                 self?.selectableRowCellSetup?(cell, row)
             }.cellUpdate { [weak self] cell, row in

--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -111,9 +111,10 @@ open class _SelectorViewController<Row: SelectableRowType, OptionsRow: OptionsPr
     public var dismissOnSelection = true
     public var dismissOnChange = true
 
+    public var selectableRowSetup: ((_ row: Row) -> Void)?
     public var selectableRowCellUpdate: ((_ cell: Row.Cell, _ row: Row) -> Void)?
     public var selectableRowCellSetup: ((_ cell: Row.Cell, _ row: Row) -> Void)?
-
+	
     /// A closure to be called when the controller disappears.
     public var onDismissCallback: ((UIViewController) -> Void)?
 
@@ -216,6 +217,7 @@ open class _SelectorViewController<Row: SelectableRowType, OptionsRow: OptionsPr
                 lrow.title = self.row.displayValueFor?(option)
                 lrow.selectableValue = option
                 lrow.value = self.row.value == option ? option : nil
+                self.selectableRowSetup?(lrow)
             }.cellSetup { [weak self] cell, row in
                 self?.selectableRowCellSetup?(cell, row)
             }.cellUpdate { [weak self] cell, row in


### PR DESCRIPTION
Currently the functionality to specify a custom `CellProvider` or `cellStyle` to be used for a `SelectorViewController`s rows is broken.

A `CellProvider` / `cellStyle` may be set on the row using the `selectableRowCellSetup`'callback, however this does not work as this callback occurs *after the cell has already been created.*

To resolve this issue, another callback `selectableRowSetup` is proposed, that is fired after the row is created, but before the cell is created.