### PR TITLE
Fix: Inconsistencies when using SwipeAction

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -935,11 +935,9 @@ extension FormViewController : UITableViewDelegate {
 		return form[indexPath].trailingSwipe.contextualConfiguration
 	}
 
-	public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]?{
-        guard let actions = form[indexPath].trailingSwipe.contextualActions as? [UITableViewRowAction], !actions.isEmpty else {
-            return nil
-        }
-        return actions
+	public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+		let actions = form[indexPath].trailingSwipe.tableViewRowActions
+		return !actions.isEmpty ? actions : nil
 	}
 }
 

--- a/Source/Core/SwipeActions.swift
+++ b/Source/Core/SwipeActions.swift
@@ -25,31 +25,39 @@ public class SwipeAction: ContextualAction {
     }
 
     func contextualAction(forRow: BaseRow) -> ContextualAction {
-        var action: ContextualAction
         if #available(iOS 11, *){
-            action = UIContextualAction(style: style.contextualStyle as! UIContextualAction.Style, title: title){ [weak self] action, view, completion -> Void in
+            let action = UIContextualAction(style: style.contextualStyle as! UIContextualAction.Style, title: title){ [weak self] action, view, completion -> Void in
                 guard let strongSelf = self else{ return }
                 strongSelf.handler(strongSelf, forRow, completion)
             }
-        } else {
-            action = UITableViewRowAction(style: style.contextualStyle as! UITableViewRowActionStyle,title: title){ [weak self] (action, indexPath) -> Void in
-                guard let strongSelf = self else{ return }
-				strongSelf.handler(strongSelf, forRow) { _ in
-					DispatchQueue.main.async {
-						guard action.style == .destructive else {
-							forRow.baseCell?.formViewController()?.tableView?.setEditing(false, animated: true)
-							return
-						}
-						forRow.section?.remove(at: indexPath.row)
-					}
-				}
-            }
+			
+			action.backgroundColor = self.backgroundColor ?? action.backgroundColor
+			action.image = self.image ?? action.image
+			
+			return action
         }
-        action.backgroundColor = self.backgroundColor ?? action.backgroundColor
-        action.image = self.image ?? action.image
-        
-        return action
+		
+		return tableViewRowAction(forRow: forRow)
     }
+	
+	func tableViewRowAction(forRow: BaseRow) -> UITableViewRowAction {
+		let action = UITableViewRowAction(style: style.tableViewRowStyle, title: title) { [weak self] (action, indexPath) -> Void in
+			guard let strongSelf = self else { return }
+			strongSelf.handler(strongSelf, forRow) { _ in
+				DispatchQueue.main.async {
+					guard action.style == .destructive else {
+						forRow.baseCell?.formViewController()?.tableView?.setEditing(false, animated: true)
+						return
+					}
+					forRow.section?.remove(at: indexPath.row)
+				}
+			}
+		}
+		action.backgroundColor = self.backgroundColor ?? action.backgroundColor
+		action.image = self.image ?? action.image
+		
+		return action
+	}
 	
     public enum Style{
         case normal
@@ -64,14 +72,18 @@ public class SwipeAction: ContextualAction {
                     return UIContextualAction.Style.destructive
                 }
             } else {
-                switch self{
-                case .normal:
-                    return UITableViewRowActionStyle.normal
-                case .destructive:
-                    return UITableViewRowActionStyle.destructive
-                }
+				return tableViewRowStyle
             }
         }
+		
+		var tableViewRowStyle: UITableViewRowActionStyle {
+			switch self {
+			case .normal:
+				return UITableViewRowActionStyle.normal
+			case .destructive:
+				return UITableViewRowActionStyle.destructive
+			}
+		}
     }
 }
 
@@ -95,9 +107,13 @@ extension SwipeConfiguration {
         return contextualConfiguration
     }
 
-    var contextualActions: [ContextualAction]{
+    var contextualActions: [ContextualAction] {
         return self.actions.map { $0.contextualAction(forRow: self.row) }
     }
+	
+	var tableViewRowActions: [UITableViewRowAction] {
+		return self.actions.map { $0.tableViewRowAction(forRow: self.row) }
+	}
 }
 
 protocol ContextualAction {


### PR DESCRIPTION
Problem:

On iOS 10 and lower, when adding a trailing `SwipeAction` to a `Row`, this action is cast to a `UITableViewRowAction` and returned from `tableView(_:editActionsForRowAt:)` in `FormViewController`. Unfortunately the same does not happen on iOS 11, since there a `SwipeAction` is cast to `UIContextualAction` instead of `UITableViewRowAction`, leaving `tableView(_:editActionsForRowAt:)` to return nothing and making UIKit fall back to default behavior.

This leads to inconsistent behavior between iOS versions, which is, of course, unfavorable.

Solution:

I propose the introduction of `tableViewRowAction(forRow:)` alongside the already existing `func contextualAction(forRow:)`. This way, in `tableView(_:editActionsForRowAt:)`, we can explicitly request `UITableViewRowActions` and establish consistent behavior across iOS versions.

Demo:

Given the following form setup…

```
form +++ Section("Rows")
	<<< LabelRow {
		$0.title = "← Delete me!"
		
		let action = SwipeAction(style: .destructive, title: " Bam! 💥", handler: { (action, row, completionBlock) in
			completionBlock?(true)
		})
		
		action.backgroundColor = UIColor.darkGray
		
		$0.trailingSwipe.actions = [action]
	}

tableView.setEditing(true, animated: false)
```

… the current behavior when tapping the delete icon on iOS 11 is as follows:

![current_behavior](https://user-images.githubusercontent.com/13534620/38455030-41499fe4-3a72-11e8-87b4-7fd216e53a9b.gif)

The expected behavior, however, is the same as it already is on iOS 10 and lower:

![expected_behavior](https://user-images.githubusercontent.com/13534620/38455051-83a3c612-3a72-11e8-9779-e35c2b4bd6ff.gif)
