### PR TITLE
Support attributed strings in picker rows

### DIFF
--- a/Source/Rows/PickerRow.swift
+++ b/Source/Rows/PickerRow.swift
@@ -75,7 +75,7 @@ open class PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerVi
     open func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
-    
+
     open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         return pickerRow?.options.count ?? 0
     }

--- a/Source/Rows/PickerRow.swift
+++ b/Source/Rows/PickerRow.swift
@@ -75,7 +75,7 @@ open class PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerVi
     open func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
-
+    
     open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         return pickerRow?.options.count ?? 0
     }
@@ -84,6 +84,16 @@ open class PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerVi
         return pickerRow?.displayValueFor?(pickerRow?.options[row])
     }
 
+    public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+        guard
+            let attributes = pickerRow?.onProvideStringAttributes?(),
+            let title = self.pickerView(pickerView, titleForRow: row, forComponent: component)
+        else {
+            return nil
+        }
+        return NSAttributedString(string: title, attributes: attributes)
+    }
+    
     open func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         if let picker = pickerRow, !picker.options.isEmpty {
             picker.value = picker.options[row]
@@ -97,6 +107,7 @@ open class PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerVi
 open class _PickerRow<T> : Row<PickerCell<T>> where T: Equatable {
 
     open var options = [T]()
+    open var onProvideStringAttributes: (() -> ([NSAttributedStringKey : Any]))?
 
     required public init(tag: String?) {
         super.init(tag: tag)


### PR DESCRIPTION
This adds support for specifying titles for picker rows as attributed strings, allowing for further customisation of how the picker displays its titles. If `onProvideStringAttributes ` is not set, then previous functionality is retained.