### PR TITLE
Fix multivalued section isEditing setting

### DIFF
--- a/Eureka.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Eureka.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example/Controllers/MultivaluedExamples.swift
+++ b/Example/Example/Controllers/MultivaluedExamples.swift
@@ -217,7 +217,7 @@ class MultivaluedOnlyDeleteController: FormViewController {
         tableView.isEditing = false
         let nameList = ["family", "male", "female", "client"]
 
-        let section = MultivaluedSection(multivaluedOptions: .Delete, footer: "you can swipe to delete when table.isEditing = false (Not Editing)")
+        let section = MultivaluedSection(multivaluedOptions: .Delete)
 
 
         for tag in nameList {

--- a/Example/Example/Controllers/SwipeActionsController.swift
+++ b/Example/Example/Controllers/SwipeActionsController.swift
@@ -13,7 +13,7 @@ class SwipeActionsController: FormViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        form +++ Section(footer: "Eureka sets table.isEditing = false for SwipeActions.\n\nMultivaluedSections need table.isEditing = true, therefore both can't be used on the same view.")
+        form +++ Section(footer: "Eureka sets table.isEditing = true only if the form contains a MultivaluedSection. SwipeActions only work when isEditing = false, therefore you have to set that in ViewWillAppear. Both can't be used on the same form.")
             <<< LabelRow("Actions Right: iOS >= 7") {
                 $0.title = $0.tag
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,10 @@ Eureka automatically adds a button row when we create a insertable multivalued s
 
 There are some considerations we need to have in mind when creating insertable sections. Any row added to the insertable multivalued section should be placed above the row that Eureka automatically adds to insert new rows. This can be easily achieved by adding these additional rows to the section from inside the section's initializer closure (last parameter of section initializer) so then Eureka adds the adds insert button at the end of the section.
 
+#### Editing mode
+
+By default Eureka will set the tableView's `isEditing` to true only if there is a MultivaluedSection in the form. This will be done in `viewWillAppear` the first time a form is presented.
+
 For more information on how to use multivalued sections please take a look at Eureka example project which contains several usage examples.
 
 ### Validations
@@ -624,6 +628,9 @@ let row = TextRow() {
             $0.leadingSwipe.performsFirstActionWithFullSwipe = true
         }
 ```
+
+Swipe Actions need `tableView.isEditing` be set to `false`. Eureka will set this to `true` if there is a MultivaluedSection in the form (in the `viewWillAppear`).
+If you have both MultivaluedSections and swipe actions in the same form you should set `isEditing` according to your needs.
 
 ## Custom rows
 

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -502,7 +502,7 @@ open class FormViewController: UIViewController, FormViewControllerProtocol, For
         NotificationCenter.default.addObserver(self, selector: #selector(FormViewController.keyboardWillShow(_:)), name: Notification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(FormViewController.keyboardWillHide(_:)), name: Notification.Name.UIKeyboardWillHide, object: nil)
 
-        if form.containsMultivaluedSection {
+        if form.containsMultivaluedSection && (isBeingPresented || isMovingToParentViewController) {
             tableView.setEditing(true, animated: false)
         }
     }

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -354,7 +354,7 @@ extension Form {
     }
 	
 	var containsMultivaluedSection: Bool {
-		return kvoWrapper.sections.contains { $0 is MultivaluedSection }
+		return kvoWrapper._allSections.contains { $0 is MultivaluedSection }
 	}
 
     func getValues(for rows: [BaseRow]) -> [String: Any?] {


### PR DESCRIPTION
This was changed with SwipeActions. 

`isEditing` is now being set in viewWillAppear (only first time) if there is a MultivaluedSection in the form (even if it is hidden)

Fixes #1478 
Fixes #1503 
