### PR TITLE
Fix for issue #1490

### DIFF
--- a/Source/Rows/DoublePickerInputRow.swift
+++ b/Source/Rows/DoublePickerInputRow.swift
@@ -39,9 +39,9 @@ open class DoublePickerInputCell<A, B> : _PickerInputCell<Tuple<A, B>> where A: 
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         if component == 0 {
-            return String(describing: pickerRow.firstOptions()[row])
+            return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else {
-            return String(describing: pickerRow.secondOptions(pickerRow.selectedFirst())[row])
+            return pickerRow.displayValueForSecondRow(pickerRow.secondOptions(pickerRow.selectedFirst())[row])
         }
     }
 
@@ -80,6 +80,11 @@ open class _DoublePickerInputRow<A: Equatable, B: Equatable> : Row<DoublePickerI
     public var firstOptions: (() -> [A]) = {[]}
     /// Options for second component given the selected value from the first component. Will be called often so should be O(1)
     public var secondOptions: ((A) -> [B]) = {_ in []}
+    
+    /// Modify the displayed values for the first picker row.
+    public var displayValueForFirstRow: ((A) -> (String)) = { a in return String(describing: a) }
+    /// Modify the displayed values for the second picker row.
+    public var displayValueForSecondRow: ((B) -> (String)) = { b in return String(describing: b) }
     
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Source/Rows/DoublePickerRow.swift
+++ b/Source/Rows/DoublePickerRow.swift
@@ -59,9 +59,9 @@ open class DoublePickerCell<A, B> : _PickerCell<Tuple<A, B>> where A: Equatable,
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         if component == 0 {
-            return String(describing: pickerRow.firstOptions()[row])
+            return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else {
-            return String(describing: pickerRow.secondOptions(pickerRow.selectedFirst())[row])
+            return pickerRow.displayValueForSecondRow(pickerRow.secondOptions(pickerRow.selectedFirst())[row])
         }
     }
 
@@ -99,6 +99,11 @@ open class _DoublePickerRow<A, B> : Row<DoublePickerCell<A, B>> where A: Equatab
     public var firstOptions: (() -> [A]) = {[]}
     /// Options for second component given the selected value from the first component. Will be called often so should be O(1)
     public var secondOptions: ((A) -> [B]) = {_ in []}
+    
+    /// Modify the displayed values for the first picker row.
+    public var displayValueForFirstRow: ((A) -> (String)) = { a in return String(describing: a) }
+    /// Modify the displayed values for the second picker row.
+    public var displayValueForSecondRow: ((B) -> (String)) = { b in return String(describing: b) }
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Source/Rows/TriplePickerInputRow.swift
+++ b/Source/Rows/TriplePickerInputRow.swift
@@ -47,11 +47,11 @@ open class TriplePickerInputCell<A, B, C> : _PickerInputCell<Tuple3<A, B, C>> wh
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         if component == 0 {
-            return String(describing: pickerRow.firstOptions()[row])
+            return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else if component == 1 {
-            return String(describing: pickerRow.secondOptions(pickerRow.selectedFirst())[row])
+            return pickerRow.displayValueForSecondRow(pickerRow.secondOptions(pickerRow.selectedFirst())[row])
         } else {
-            return String(describing: pickerRow.thirdOptions(pickerRow.selectedFirst(), pickerRow.selectedSecond())[row])
+            return pickerRow.displayValueForThirdRow(pickerRow.thirdOptions(pickerRow.selectedFirst(), pickerRow.selectedSecond())[row])
         }
     }
 
@@ -120,6 +120,13 @@ open class _TriplePickerInputRow<A: Equatable, B: Equatable, C: Equatable> : Row
     public var secondOptions: ((A) -> [B]) = {_ in []}
     /// Options for third component given the selected value from the first and second components. Will be called often so should be O(1)
     public var thirdOptions: ((A, B) -> [C]) = {_, _ in []}
+    
+    /// Modify the displayed values for the first picker row.
+    public var displayValueForFirstRow: ((A) -> (String)) = { a in return String(describing: a) }
+    /// Modify the displayed values for the second picker row.
+    public var displayValueForSecondRow: ((B) -> (String)) = { b in return String(describing: b) }
+    /// Modify the displayed values for the third picker row.
+    public var displayValueForThirdRow: ((C) -> (String)) = { c in return String(describing: c) }
 
     required public init(tag: String?) {
         super.init(tag: tag)

--- a/Source/Rows/TriplePickerRow.swift
+++ b/Source/Rows/TriplePickerRow.swift
@@ -68,11 +68,11 @@ open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equ
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         if component == 0 {
-            return String(describing: pickerRow.firstOptions()[row])
+            return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else if component == 1 {
-            return String(describing: pickerRow.secondOptions(pickerRow.selectedFirst())[row])
+            return pickerRow.displayValueForSecondRow(pickerRow.secondOptions(pickerRow.selectedFirst())[row])
         } else {
-            return String(describing: pickerRow.thirdOptions(pickerRow.selectedFirst(), pickerRow.selectedSecond())[row])
+            return pickerRow.displayValueForThirdRow(pickerRow.thirdOptions(pickerRow.selectedFirst(), pickerRow.selectedSecond())[row])
         }
     }
 
@@ -140,6 +140,13 @@ open class _TriplePickerRow<A, B, C> : Row<TriplePickerCell<A, B, C>> where A: E
     public var secondOptions: ((A) -> [B]) = {_ in []}
     /// Options for third component given the selected value from the first and second components. Will be called often so should be O(1)
     public var thirdOptions: ((A, B) -> [C]) = {_, _ in []}
+    
+    /// Modify the displayed values for the first picker row.
+    public var displayValueForFirstRow: ((A) -> (String)) = { a in return String(describing: a) }
+    /// Modify the displayed values for the second picker row.
+    public var displayValueForSecondRow: ((B) -> (String)) = { b in return String(describing: b) }
+    /// Modify the displayed values for the third picker row.
+    public var displayValueForThirdRow: ((C) -> (String)) = { c in return String(describing: c) }
 
     required public init(tag: String?) {
         super.init(tag: tag)


### PR DESCRIPTION
Added the ability to customize the display value for DoublePickerRow and TriplePickerRow.

Here's a usage example that mimics a date picker:
```swift
<<< TriplePickerRow<Int, Int, String> { row in
    row.firstOptions = { Array(1...12) }
    row.secondOptions = { _ in return Array(0...59) }
    row.thirdOptions = { _,_ in return ["am", "pm"] }
    
    row.displayValueForFirstRow = { a in return String(a) } // stringifies `a`
    row.displayValueForSecondRow = { b in return String(format: "%02d", b) } // adds padding 0s if `b < 10`
    row.displayValueForThirdRow = { c in return c.capitalized } // capitalizes `c`
    
    row.value = Tuple3(a: 4, b: 5, c: "AM") // will display as 4 | 05 | AM
}
```