### PR TITLE
Add ability to customise the text color of UIPickerView used by PickerRow

### DIFF
--- a/Source/Rows/PickerRow.swift
+++ b/Source/Rows/PickerRow.swift
@@ -69,6 +69,8 @@ open class _PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerV
         picker?.dataSource = nil
     }
 
+    open var pickerTextColor: UIColor?
+
     open func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
@@ -87,6 +89,12 @@ open class _PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerV
         }
     }
 
+    open func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+        guard let pickerTextColor = pickerTextColor, let text = self.pickerView(pickerView, titleForRow: row, forComponent: component) else {
+            return nil
+        }
+        return NSAttributedString(string: text, attributes: [.foregroundColor: pickerTextColor])
+    }
 }
 
 open class PickerCell<T> : _PickerCell<T> where T: Equatable {

--- a/Source/Rows/PickerRow.swift
+++ b/Source/Rows/PickerRow.swift
@@ -69,7 +69,7 @@ open class _PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerV
         picker?.dataSource = nil
     }
 
-    open var pickerTextColor: UIColor?
+    open var pickerTextAttributes: [NSAttributedStringKey: Any]?
 
     open func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
@@ -90,10 +90,10 @@ open class _PickerCell<T> : Cell<T>, CellType, UIPickerViewDataSource, UIPickerV
     }
 
     open func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-        guard let pickerTextColor = pickerTextColor, let text = self.pickerView(pickerView, titleForRow: row, forComponent: component) else {
+        guard let pickerTextAttributes = pickerTextAttributes, let text = self.pickerView(pickerView, titleForRow: row, forComponent: component) else {
             return nil
         }
-        return NSAttributedString(string: text, attributes: [.foregroundColor: pickerTextColor])
+        return NSAttributedString(string: text, attributes: pickerTextAttributes)
     }
 }
 


### PR DESCRIPTION
It would be very helpful to be able to customise the display of the UIPickerView used in PickerRows. Setting the background color is easy, but changing the text color is tricky. I came across the `UIPickerViewDelegate` function [`pickerView(_:attributedTitleForRow:forComponent:)`](https://developer.apple.com/documentation/uikit/uipickerviewdelegate/1614375-pickerview) which returns an `NSAttributedString` (which can specify color).

In my project which uses Eureka, I couldn't find any way that I could implement that function and reuse the existing PickerCell: I ended up having to duplicate the PickerCell / PickerRow code, and add the extra method to PickerCell. It would be very nice to have this customisation built-in, which is what this commit does.

I am using it in `defaultCellUpdate`; something like the following:

```
PickerInlineRow<Language>.InlineRow.defaultCellUpdate = { cell, _ in
   cell.pickerTextColor = .white
   cell.backgroundColor = .black
}
```

Note that the documentation states that:

> if your implementation of this method returns nil, the picker view falls back to using the string returned by the pickerView(_:titleForRow:forComponent:) method.

So cells with unspecified `pickerTextColor` will exhibit the existing behaviour.