### PR TITLE
Fix crash with double and triple picker rows

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -842,7 +842,7 @@ extension FormViewController : UITableViewDelegate {
                 fatalError("Multivalued section multivaluedRowToInsertAt property must be set up")
             }
             let newRow = multivaluedRowToInsertAt(max(0, section.count - 1))
-            section.insert(newRow, at: section.count - 1)
+            section.insert(newRow, at: max(0, section.count - 1))
             DispatchQueue.main.async {
                 tableView.isEditing = !tableView.isEditing
                 tableView.isEditing = !tableView.isEditing

--- a/Source/Rows/DoublePickerRow.swift
+++ b/Source/Rows/DoublePickerRow.swift
@@ -30,7 +30,7 @@ public func == <A: Equatable, B: Equatable>(lhs: Tuple<A, B>, rhs: Tuple<A, B>) 
 
 open class DoublePickerCell<A, B> : _PickerCell<Tuple<A, B>> where A: Equatable, B: Equatable {
 
-    private var pickerRow: _DoublePickerRow<A, B>! { return row as? _DoublePickerRow<A, B> }
+    private var pickerRow: _DoublePickerRow<A, B>? { return row as? _DoublePickerRow<A, B> }
 
     public required init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -42,8 +42,8 @@ open class DoublePickerCell<A, B> : _PickerCell<Tuple<A, B>> where A: Equatable,
 
     open override func update() {
         super.update()
-        if let selectedValue = pickerRow.value, let indexA = pickerRow.firstOptions().index(of: selectedValue.a),
-            let indexB = pickerRow.secondOptions(selectedValue.a).index(of: selectedValue.b) {
+        if let selectedValue = pickerRow?.value, let indexA = pickerRow?.firstOptions().index(of: selectedValue.a),
+            let indexB = pickerRow?.secondOptions(selectedValue.a).index(of: selectedValue.b) {
             picker.selectRow(indexA, inComponent: 0, animated: true)
             picker.selectRow(indexB, inComponent: 1, animated: true)
         }
@@ -54,10 +54,12 @@ open class DoublePickerCell<A, B> : _PickerCell<Tuple<A, B>> where A: Equatable,
     }
 
     open override func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return  component == 0 ? pickerRow.firstOptions().count : pickerRow.secondOptions(pickerRow.selectedFirst()).count
+        guard let pickerRow = pickerRow else { return 0 }
+        return component == 0 ? pickerRow.firstOptions().count : pickerRow.secondOptions(pickerRow.selectedFirst()).count
     }
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        guard let pickerRow = pickerRow else { return "" }
         if component == 0 {
             return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else {
@@ -66,6 +68,7 @@ open class DoublePickerCell<A, B> : _PickerCell<Tuple<A, B>> where A: Equatable,
     }
 
     open override func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        guard let pickerRow = pickerRow else { return }
         if component == 0 {
             let a = pickerRow.firstOptions()[row]
             if let value = pickerRow.value {

--- a/Source/Rows/TriplePickerRow.swift
+++ b/Source/Rows/TriplePickerRow.swift
@@ -31,7 +31,7 @@ public func == <A: Equatable, B: Equatable, C: Equatable>(lhs: Tuple3<A, B, C>, 
 
 open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equatable, B: Equatable, C: Equatable {
 
-    private var pickerRow: _TriplePickerRow<A, B, C>! { return row as? _TriplePickerRow<A, B, C> }
+    private var pickerRow: _TriplePickerRow<A, B, C>? { return row as? _TriplePickerRow<A, B, C> }
 
     public required init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -43,9 +43,9 @@ open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equ
 
     open override func update() {
         super.update()
-        if let selectedValue = pickerRow.value, let indexA = pickerRow.firstOptions().index(of: selectedValue.a),
-            let indexB = pickerRow.secondOptions(selectedValue.a).index(of: selectedValue.b),
-            let indexC = pickerRow.thirdOptions(selectedValue.a, selectedValue.b).index(of: selectedValue.c) {
+        if let selectedValue = pickerRow?.value, let indexA = pickerRow?.firstOptions().index(of: selectedValue.a),
+            let indexB = pickerRow?.secondOptions(selectedValue.a).index(of: selectedValue.b),
+            let indexC = pickerRow?.thirdOptions(selectedValue.a, selectedValue.b).index(of: selectedValue.c) {
             picker.selectRow(indexA, inComponent: 0, animated: true)
             picker.selectRow(indexB, inComponent: 1, animated: true)
             picker.selectRow(indexC, inComponent: 2, animated: true)
@@ -57,6 +57,7 @@ open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equ
     }
 
     open override func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        guard let pickerRow = pickerRow else { return 0 }
         if component == 0 {
             return pickerRow.firstOptions().count
         } else if component == 1 {
@@ -67,6 +68,7 @@ open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equ
     }
 
     open override func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        guard let pickerRow = pickerRow else { return "" }
         if component == 0 {
             return pickerRow.displayValueForFirstRow(pickerRow.firstOptions()[row])
         } else if component == 1 {
@@ -77,6 +79,7 @@ open class TriplePickerCell<A, B, C> : _PickerCell<Tuple3<A, B, C>> where A: Equ
     }
 
     open override func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        guard let pickerRow = pickerRow else { return }
         if component == 0 {
             let a = pickerRow.firstOptions()[row]
             if let value = pickerRow.value {


### PR DESCRIPTION
The crash happens when you have one of these rows as inline rows andyou edit the picker's value and then collapse the inline row before the action takes place. This results in a delegate method called on the cell, when the row for that cell has possibly been deleted.

Fix #1587