### PR TITLE
Make presenter rows onPresent result discardable

### DIFF
--- a/Source/Core/PresenterRowType.swift
+++ b/Source/Core/PresenterRowType.swift
@@ -48,6 +48,7 @@ extension PresenterRowType {
      
      - returns: this row
      */
+    @discardableResult
     public func onPresent(_ callback: ((FormViewController, PresentedControllerType) -> Void)?) -> Self {
         onPresentCallback = callback
         return self


### PR DESCRIPTION
### Motivation
```swift
<<< PushRow<Something>("tag") { row in
    row.onPresent { from, to in
        // whatever
    }
}
```
Calling onPresent as shown above triggers compiler warning `Result of call to 'onPresent' is unused`.
This PR addresses this issue for those who prefer not to chain the method and don't like compiler warnings (like me 😜).

### Solution
Add  `@discardableResult` annotation. It is already used in other similar methods such as `onChange` or `onCellSelection`.