### PR TITLE
Chevron's must be loaded from Eureka's bundle

### DIFF
--- a/Source/Core/NavigationAccessoryView.swift
+++ b/Source/Core/NavigationAccessoryView.swift
@@ -45,7 +45,7 @@ open class NavigationAccessoryView: UIToolbar {
     }
 
     private func initializeChevrons() {
-        var bundle = Bundle(for: self.classForCoder)
+        var bundle = Bundle(for: NavigationAccessoryView.classForCoder())
         if let resourcePath = bundle.path(forResource: "Eureka", ofType: "bundle") {
             if let resourcesBundle = Bundle(path: resourcePath) {
                 bundle = resourcesBundle


### PR DESCRIPTION
Fixes an issue where the images of the NavigationAccessoryView might not be loaded if it is subclassed.