### PR TITLE
Make `FieldCell's` textField public to allow overrides

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -130,7 +130,7 @@ extension TextFieldCell {
 
 open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: Equatable, T: InputTypeInitiable {
 
-    @IBOutlet public weak var textField: UITextField!
+    @IBOutlet open weak var textField: UITextField!
     @IBOutlet public weak var titleLabel: UILabel?
 
     fileprivate var observingTitleText = false


### PR DESCRIPTION
It allows us to  use custom textfield classes in subclasses of FieldCell without having to duplicate the whole code.

Example for phone formatting using SHSPhoneTextField:

```swift
final class CustomPhoneCell : _FieldCell<String>, CellType {
    private lazy var phoneField : SHSPhoneTextField = {
        let textField = SHSPhoneTextField()
        textField.translatesAutoresizingMaskIntoConstraints = false
        textField.formatter.setDefaultOutputPattern("###-###-####")
        textField.textDidChangeBlock = { [weak self] txtField in
            self?.textFieldDidChange(txtField!)
        }
        return textField
    }()

    override var textField : UITextField! {
        get {
            return self.phoneField
        }
        set{
            self.textField = phoneField
        }
    }

    required init(style: UITableViewCellStyle, reuseIdentifier: String?) {
        super.init(style: style, reuseIdentifier: reuseIdentifier)
        for subView in contentView.subviews {
            if subView is UITextField {
                subView.removeFromSuperview()
            }
        }
        contentView.addSubview(phoneField)
    }

    required init?(coder aDecoder: NSCoder) {
        super.init(coder: aDecoder)
    }
}
```