### PR TITLE
Declare swift language version required in podspec

### DIFF
--- a/Eureka.podspec
+++ b/Eureka.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift'
   s.resources = 'Source/Resources/Eureka.bundle'
   s.requires_arc = true
+  s.swift_version = '4.2'
 end


### PR DESCRIPTION
Projects that depend on Eureka and install xcode 10 run into
errors because they may still be building with swift language
version 4.1 which the Eureka pod will inherit (because it is not
otherwise specified) and then the Eureka pod fails to build

Cocoapods will respect this setting when generating targets so
as Eureka changes the specific swift version it targets this setting
should reflect that.

