### PR TITLE
Set textContentType for relevant cells

### DIFF
--- a/Source/Rows/FieldsRow.swift
+++ b/Source/Rows/FieldsRow.swift
@@ -109,6 +109,9 @@ open class EmailCell: _FieldCell<String>, CellType {
         textField.autocorrectionType = .no
         textField.autocapitalizationType = .none
         textField.keyboardType = .emailAddress
+        if #available(iOS 10,*) {
+            textField.textContentType = .emailAddress
+        }
     }
 }
 
@@ -128,6 +131,9 @@ open class PasswordCell: _FieldCell<String>, CellType {
         textField.autocapitalizationType = .none
         textField.keyboardType = .asciiCapable
         textField.isSecureTextEntry = true
+        if #available(iOS 11,*) {
+            textField.textContentType = .password
+        }
     }
 }
 
@@ -163,6 +169,9 @@ open class URLCell: _FieldCell<URL>, CellType {
         textField.autocorrectionType = .no
         textField.autocapitalizationType = .none
         textField.keyboardType = .URL
+        if #available(iOS 10,*) {
+            textField.textContentType = .URL
+        }
     }
 }
 
@@ -199,6 +208,9 @@ open class AccountCell: _FieldCell<String>, CellType {
         textField.autocorrectionType = .no
         textField.autocapitalizationType = .none
         textField.keyboardType = .asciiCapable
+        if #available(iOS 11,*) {
+            textField.textContentType = .username
+        }
     }
 }
 


### PR DESCRIPTION
This PR sets [`textContentType`](https://developer.apple.com/documentation/uikit/uitextinputtraits/1649656-textcontenttype) to the correct values on `EmailCell`, `PasswordCell`, `URLCell` and `UsernameCell` which enables [password autofill](https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_a_text_input_view) as well as allowing the system to attempt to autofill values when possible. The property was introduced in iOS 10. `.username` and `.password` were only added in iOS 11.