### PR TITLE
Avoid segmented row title label pushing value out of bounds

### DIFF
--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -46,6 +46,7 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
         self.titleLabel = self.textLabel
         self.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
         self.titleLabel?.setContentHuggingPriority(UILayoutPriority(rawValue: 500), for: .horizontal)
+        self.titleLabel?.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { [weak self] _ in
             guard let me = self else { return }


### PR DESCRIPTION
If you have a long title then set `cell.titleLabel?.numberOfLines = 0` and set an appropriate height.