### PR TITLE
Add `allRows` variable to Section

### DIFF
--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -149,8 +149,13 @@ open class Section {
         didSet { addToRowObservers() }
     }
 
-    /// Returns if the section is currently hidden or not
+    /// Returns if the section is currently hidden or not.
     public var isHidden: Bool { return hiddenCache }
+
+    /// Returns all the rows in this section, including hidden rows.
+    public var allRows: [BaseRow] {
+        return kvoWrapper._allRows
+    }
 
     public required init() {}
 


### PR DESCRIPTION
This allows easier access to all the rows (including hidden) of a Section.