### PR TITLE
Fix #1674 by removing double `isEditing` switch

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -842,10 +842,6 @@ extension FormViewController : UITableViewDelegate {
                 tableView.endEditing(true)
             }
             section.remove(at: indexPath.row)
-            DispatchQueue.main.async {
-                tableView.isEditing = !tableView.isEditing
-                tableView.isEditing = !tableView.isEditing
-            }
         } else if editingStyle == .insert {
             guard var section = form[indexPath.section] as? MultivaluedSection else { return }
             guard let multivaluedRowToInsertAt = section.multivaluedRowToInsertAt else {


### PR DESCRIPTION
Closes #1674 

Tested on iOS 12.0 and 11.4