### PR TITLE
Allow the row to reset its own value

### DIFF
--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -63,6 +63,13 @@ open class RowOf<T>: BaseRow where T: Equatable{
             return _value
         }
     }
+    
+    /// The default value of this row. Sets the value property when setted or when the setDefaultValue is called.
+    open var defaultValue: T? {
+        didSet {
+            value = defaultValue
+        }
+    }
 
     /// The untyped value of this row.
     public override var baseValue: Any? {
@@ -89,6 +96,11 @@ open class RowOf<T>: BaseRow where T: Equatable{
         validationErrors = rules.flatMap { $0.validateFn(value) }
         #endif
         return validationErrors
+    }
+    
+    /// Resets the value of the row. Settings it's value to it's default value.
+    public func resetValue() {
+        value = defaultValue
     }
 
     /// Add a Validation rule for the Row

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -64,12 +64,8 @@ open class RowOf<T>: BaseRow where T: Equatable{
         }
     }
     
-    /// The default value of this row. Sets the value property when setted or when the setDefaultValue is called.
-    open var defaultValue: T? {
-        didSet {
-            value = defaultValue
-        }
-    }
+    /// The reset value of this row. Sets the value property to the value of this row on the resetValue method call.
+    open var resetValue: T?
 
     /// The untyped value of this row.
     public override var baseValue: Any? {
@@ -98,9 +94,9 @@ open class RowOf<T>: BaseRow where T: Equatable{
         return validationErrors
     }
     
-    /// Resets the value of the row. Settings it's value to it's default value.
-    public func resetValue() {
-        value = defaultValue
+    /// Resets the value of the row. Setting it's value to it's reset value.
+    public func resetRowValue() {
+        value = resetValue
     }
 
     /// Add a Validation rule for the Row

--- a/Tests/SetValuesTests.swift
+++ b/Tests/SetValuesTests.swift
@@ -86,8 +86,8 @@ class SetValuesTests: XCTestCase {
         XCTAssertNil(intRow?.value)
     }
     
-    // Once you set the default value, the value property should be set aswell. When you change the value, it should change as usual, but the default value should be the same, since we're changing the value but not the row's default.
-    func testSetDefaultValues() {
+    // The reset value stores the default value of the row. The reset value should not change along with the value property, and when you reset the row value, it should set the value property to the reset value.
+    func testSetAndResetValues() {
         let intValue: Int = 4
         let intDefaultvalue: Int = 0
         let stringValue = "String Value!"
@@ -97,57 +97,42 @@ class SetValuesTests: XCTestCase {
         
         let intRow: IntRow? = form.rowBy(tag: "IntRow")
         XCTAssertNotNil(intRow)
-        intRow?.defaultValue = intDefaultvalue
-        XCTAssertEqual(intRow?.defaultValue, intDefaultvalue)
-        XCTAssertEqual(intRow?.value, intDefaultvalue)
+        intRow?.resetValue = intDefaultvalue
+        XCTAssertEqual(intRow?.resetValue, intDefaultvalue)
         intRow?.value = intValue
-        XCTAssertEqual(intRow?.defaultValue, intDefaultvalue)
-        XCTAssertEqual(intRow?.value, intValue)
-        intRow?.resetValue()
+        intRow?.resetRowValue()
         XCTAssertEqual(intRow?.value, intDefaultvalue)
         
         let textRow: TextRow? = form.rowBy(tag: "TextRow")
         XCTAssertNotNil(textRow)
-        textRow?.defaultValue = stringDefaultValue
-        XCTAssertEqual(textRow?.defaultValue, stringDefaultValue)
-        XCTAssertEqual(textRow?.value, stringDefaultValue)
+        textRow?.resetValue = stringDefaultValue
+        XCTAssertEqual(textRow?.resetValue, stringDefaultValue)
         textRow?.value = stringValue
-        XCTAssertEqual(textRow?.defaultValue, stringDefaultValue)
-        XCTAssertEqual(textRow?.value, stringValue)
-        textRow?.resetValue()
+        textRow?.resetRowValue()
         XCTAssertEqual(textRow?.value, stringDefaultValue)
         
         let actionSheetRow: ActionSheetRow<String>? = form.rowBy(tag: "ActionSheetRow")
         XCTAssertNotNil(actionSheetRow)
-        actionSheetRow?.defaultValue = stringDefaultValue
-        XCTAssertEqual(actionSheetRow?.defaultValue, stringDefaultValue)
-        XCTAssertEqual(actionSheetRow?.value, stringDefaultValue)
+        actionSheetRow?.resetValue = stringDefaultValue
+        XCTAssertEqual(actionSheetRow?.resetValue, stringDefaultValue)
         actionSheetRow?.value = stringValue
-        XCTAssertEqual(actionSheetRow?.defaultValue, stringDefaultValue)
-        XCTAssertEqual(actionSheetRow?.value, stringValue)
-        actionSheetRow?.resetValue()
+        actionSheetRow?.resetRowValue()
         XCTAssertEqual(actionSheetRow?.value, stringDefaultValue)
         
         let alertRow: AlertRow<Int>? = form.rowBy(tag: "AlertRow")
         XCTAssertNotNil(alertRow)
-        alertRow?.defaultValue = intDefaultvalue
-        XCTAssertEqual(alertRow?.defaultValue, intDefaultvalue)
-        XCTAssertEqual(alertRow?.value, intDefaultvalue)
+        alertRow?.resetValue = intDefaultvalue
+        XCTAssertEqual(alertRow?.resetValue, intDefaultvalue)
         alertRow?.value = intValue
-        XCTAssertEqual(alertRow?.defaultValue, intDefaultvalue)
-        XCTAssertEqual(alertRow?.value, intValue)
-        alertRow?.resetValue()
+        alertRow?.resetRowValue()
         XCTAssertEqual(alertRow?.value, intDefaultvalue)
         
         let pushRow: PushRow<Float>? = form.rowBy(tag: "PushRow")
         XCTAssertNotNil(pushRow)
-        pushRow?.defaultValue = floatDefaultValue
-        XCTAssertEqual(pushRow?.defaultValue, floatDefaultValue)
-        XCTAssertEqual(pushRow?.value, floatDefaultValue)
+        pushRow?.resetValue = floatDefaultValue
+        XCTAssertEqual(pushRow?.resetValue, floatDefaultValue)
         pushRow?.value = floatValue
-        XCTAssertEqual(pushRow?.defaultValue, floatDefaultValue)
-        XCTAssertEqual(pushRow?.value, floatValue)
-        pushRow?.resetValue()
+        pushRow?.resetRowValue()
         XCTAssertEqual(pushRow?.value, floatDefaultValue)
         
     }

--- a/Tests/SetValuesTests.swift
+++ b/Tests/SetValuesTests.swift
@@ -85,4 +85,70 @@ class SetValuesTests: XCTestCase {
         form.setValues(["IntRow": intRowNilValue])
         XCTAssertNil(intRow?.value)
     }
+    
+    // Once you set the default value, the value property should be set aswell. When you change the value, it should change as usual, but the default value should be the same, since we're changing the value but not the row's default.
+    func testSetDefaultValues() {
+        let intValue: Int = 4
+        let intDefaultvalue: Int = 0
+        let stringValue = "String Value!"
+        let stringDefaultValue = "String Default Value!"
+        let floatValue: Float = 0.7
+        let floatDefaultValue: Float = 1.4
+        
+        let intRow: IntRow? = form.rowBy(tag: "IntRow")
+        XCTAssertNotNil(intRow)
+        intRow?.defaultValue = intDefaultvalue
+        XCTAssertEqual(intRow?.defaultValue, intDefaultvalue)
+        XCTAssertEqual(intRow?.value, intDefaultvalue)
+        intRow?.value = intValue
+        XCTAssertEqual(intRow?.defaultValue, intDefaultvalue)
+        XCTAssertEqual(intRow?.value, intValue)
+        intRow?.resetValue()
+        XCTAssertEqual(intRow?.value, intDefaultvalue)
+        
+        let textRow: TextRow? = form.rowBy(tag: "TextRow")
+        XCTAssertNotNil(textRow)
+        textRow?.defaultValue = stringDefaultValue
+        XCTAssertEqual(textRow?.defaultValue, stringDefaultValue)
+        XCTAssertEqual(textRow?.value, stringDefaultValue)
+        textRow?.value = stringValue
+        XCTAssertEqual(textRow?.defaultValue, stringDefaultValue)
+        XCTAssertEqual(textRow?.value, stringValue)
+        textRow?.resetValue()
+        XCTAssertEqual(textRow?.value, stringDefaultValue)
+        
+        let actionSheetRow: ActionSheetRow<String>? = form.rowBy(tag: "ActionSheetRow")
+        XCTAssertNotNil(actionSheetRow)
+        actionSheetRow?.defaultValue = stringDefaultValue
+        XCTAssertEqual(actionSheetRow?.defaultValue, stringDefaultValue)
+        XCTAssertEqual(actionSheetRow?.value, stringDefaultValue)
+        actionSheetRow?.value = stringValue
+        XCTAssertEqual(actionSheetRow?.defaultValue, stringDefaultValue)
+        XCTAssertEqual(actionSheetRow?.value, stringValue)
+        actionSheetRow?.resetValue()
+        XCTAssertEqual(actionSheetRow?.value, stringDefaultValue)
+        
+        let alertRow: AlertRow<Int>? = form.rowBy(tag: "AlertRow")
+        XCTAssertNotNil(alertRow)
+        alertRow?.defaultValue = intDefaultvalue
+        XCTAssertEqual(alertRow?.defaultValue, intDefaultvalue)
+        XCTAssertEqual(alertRow?.value, intDefaultvalue)
+        alertRow?.value = intValue
+        XCTAssertEqual(alertRow?.defaultValue, intDefaultvalue)
+        XCTAssertEqual(alertRow?.value, intValue)
+        alertRow?.resetValue()
+        XCTAssertEqual(alertRow?.value, intDefaultvalue)
+        
+        let pushRow: PushRow<Float>? = form.rowBy(tag: "PushRow")
+        XCTAssertNotNil(pushRow)
+        pushRow?.defaultValue = floatDefaultValue
+        XCTAssertEqual(pushRow?.defaultValue, floatDefaultValue)
+        XCTAssertEqual(pushRow?.value, floatDefaultValue)
+        pushRow?.value = floatValue
+        XCTAssertEqual(pushRow?.defaultValue, floatDefaultValue)
+        XCTAssertEqual(pushRow?.value, floatValue)
+        pushRow?.resetValue()
+        XCTAssertEqual(pushRow?.value, floatDefaultValue)
+        
+    }
 }


### PR DESCRIPTION
Goal
===
The idea is to give the row the ability to reset its own value to a predefined **default**.

To do this, we create a new property to store the **default value**, that won't change along with it's **value**. Doing so, we allow the row to reset itself at anytime, since it knows its own default value.

The main idea was to create the possibility to do this in the whole `section` or `form`, just like setting the form to a default state. I couldn't find a way to do this as I didn't explore much. If you have any idea, feel free to suggest.

The main motivation was to make the code cleaner, and more understandable, as the row should be responsible for its values and the things related directly to it, in my opinion.

How to test
===
Run the `testSetDefaultValues` test.