### PR TITLE
Disable scroll on show inlineRow if position none 

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1109,6 +1109,7 @@ extension FormViewControllerProtocol {
     // MARK: Helpers
 
     func makeRowVisible(_ row: BaseRow, destinationScrollPosition: UITableView.ScrollPosition = .bottom) {
+	guard destinationScrollPosition != .none else { return }
         guard let cell = row.baseCell, let indexPath = row.indexPath, let tableView = tableView else { return }
         if cell.window == nil || (tableView.contentOffset.y + tableView.frame.size.height <= cell.frame.origin.y + cell.frame.size.height) {
             tableView.scrollToRow(at: indexPath, at: destinationScrollPosition, animated: true)


### PR DESCRIPTION
Some times it may be need to disable scroll on displaying inlineRow

UITableView.ScrollPosition.none -> scroll tableview to bottom of cell =(
