### PR TITLE
Allow `.none` scrolling as well as no scroll when making row visible

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -131,7 +131,7 @@ open class BaseRow: BaseRowType {
     /**
      Helps to pick destination part of the cell after scrolling
      */
-    open var destinationScrollPosition = UITableView.ScrollPosition.bottom
+    open var destinationScrollPosition: UITableView.ScrollPosition? = UITableView.ScrollPosition.bottom
 
     /**
      Returns the IndexPath where this row is in the current form.

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1108,8 +1108,8 @@ extension FormViewControllerProtocol {
 
     // MARK: Helpers
 
-    func makeRowVisible(_ row: BaseRow, destinationScrollPosition: UITableView.ScrollPosition = .bottom) {
-	guard destinationScrollPosition != .none else { return }
+    func makeRowVisible(_ row: BaseRow, destinationScrollPosition: UITableView.ScrollPosition? = .bottom) {
+	guard let destinationScrollPosition = destinationScrollPosition else { return }
         guard let cell = row.baseCell, let indexPath = row.indexPath, let tableView = tableView else { return }
         if cell.window == nil || (tableView.contentOffset.y + tableView.frame.size.height <= cell.frame.origin.y + cell.frame.size.height) {
             tableView.scrollToRow(at: indexPath, at: destinationScrollPosition, animated: true)


### PR DESCRIPTION
Reverts change in #1784 but allows to do that feature by setting nil to `destinationScrollPosition`