### PR TITLE
Fix backgroundColor for SwipeActions

### DIFF
--- a/Example/Example/Controllers/SwipeActionsController.swift
+++ b/Example/Example/Controllers/SwipeActionsController.swift
@@ -52,7 +52,7 @@ class SwipeActionsController: FormViewController {
                         print("Info")
                         completionHandler?(true)
                     })
-                    infoAction.backgroundColor = .blue
+                    infoAction.actionBackgroundColor = .blue
 
                     $0.leadingSwipe.actions = [infoAction]
                     $0.leadingSwipe.performsFirstActionWithFullSwipe = true

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ let row = TextRow() {
                     //make sure you call the completionHandler once done.
                     completionHandler?(true)
                 })
-            infoAction.backgroundColor = .blue
+            infoAction.actionBackgroundColor = .blue
             infoAction.image = UIImage(named: "icon-info")
 
             $0.leadingSwipe.actions = [infoAction]

--- a/Source/Core/SwipeActions.swift
+++ b/Source/Core/SwipeActions.swift
@@ -15,9 +15,15 @@ public class SwipeAction: ContextualAction {
     let handler: SwipeActionHandler
     let style: Style
 
-    public var backgroundColor: UIColor?
+    public var actionBackgroundColor: UIColor?
     public var image: UIImage?
     public var title: String?
+
+    @available (*, deprecated, message: "Use actionBackgroundColor instead")
+    public var backgroundColor: UIColor? {
+        get { return actionBackgroundColor }
+        set { self.actionBackgroundColor = newValue }
+    }
 
     public init(style: Style, title: String?, handler: @escaping SwipeActionHandler){
         self.style = style
@@ -46,8 +52,8 @@ public class SwipeAction: ContextualAction {
 				}
             }
         }
-        if let color = self.backgroundColor {
-            action.backgroundColor = color
+        if let color = self.actionBackgroundColor {
+            action.actionBackgroundColor = color
         }
         if let image = self.image {
             action.image = image
@@ -55,7 +61,7 @@ public class SwipeAction: ContextualAction {
         return action
     }
 	
-    public enum Style{
+    public enum Style {
         case normal
         case destructive
         
@@ -105,16 +111,9 @@ extension SwipeConfiguration {
 }
 
 protocol ContextualAction {
-    var backgroundColor: UIColor? { get set }
+    var actionBackgroundColor: UIColor? { get set }
     var image: UIImage? { get set }
     var title: String? { get set }
-}
-
-extension ContextualAction {
-    var backgroundColor: UIColor? {
-        get { return nil }
-        set { }
-    }
 }
 
 extension UITableViewRowAction: ContextualAction {
@@ -122,10 +121,22 @@ extension UITableViewRowAction: ContextualAction {
         get { return nil }
         set { return }
     }
+
+    public var actionBackgroundColor: UIColor? {
+        get { return backgroundColor }
+        set { self.backgroundColor = newValue }
+    }
 }
 
 @available(iOS 11.0, *)
-extension UIContextualAction: ContextualAction {}
+extension UIContextualAction: ContextualAction {
+
+    public var actionBackgroundColor: UIColor? {
+        get { return backgroundColor }
+        set { self.backgroundColor = newValue }
+    }
+
+}
 
 public protocol ContextualStyle{}
 extension UITableViewRowAction.Style: ContextualStyle {}


### PR DESCRIPTION
ContextualAction's `backgroundColor` was set to a computed properties with an empty setter and a getter that always returned `nil`.

Now it is changed to `actionBackgroundColor` which gets/sets `backgroundColor` for `UITableViewRowAction` and `UIContextualAction`

Fixes #1790 