### PR TITLE
Correctly remove observers when rows are deleted

### DIFF
--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -330,8 +330,11 @@ extension Form {
 
     func removeRowObservers(from taggable: Taggable, rowTags: [String], type: ConditionType) {
         for rowTag in rowTags {
-            guard var arr = rowObservers[rowTag]?[type], let index = arr.firstIndex(where: { $0 === taggable }) else { continue }
-            arr.remove(at: index)
+            guard let arr = rowObservers[rowTag]?[type], let index = arr.firstIndex(where: { $0 === taggable }) else { continue }
+            rowObservers[rowTag]?[type]?.remove(at: index)
+            if rowObservers[rowTag]?[type]?.isEmpty == true {
+                rowObservers[rowTag] = nil
+            }
         }
     }
 


### PR DESCRIPTION
Observers were not being removed correctly

Fix #1804 