### PR TITLE
added quietly parameter for use with non-ui validation

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -74,7 +74,7 @@ open class BaseRow: BaseRowType {
         get { return nil }
     }
 
-    public func validate() -> [ValidationError] {
+    public func validate(quietly: Bool = false) -> [ValidationError] {
         return []
     }
 

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -393,13 +393,17 @@ extension Form {
 extension Form {
 
     @discardableResult
-    public func validate(includeHidden: Bool = false, includeDisabled: Bool = true) -> [ValidationError] {
+    public func validate(includeHidden: Bool = false, includeDisabled: Bool = true, quietly: Bool = false) -> [ValidationError] {
         let rowsWithHiddenFilter = includeHidden ? allRows : rows
         let rowsWithDisabledFilter = includeDisabled ? rowsWithHiddenFilter : rowsWithHiddenFilter.filter { $0.isDisabled != true }
         
         return rowsWithDisabledFilter.reduce([ValidationError]()) { res, row in
             var res = res
-            res.append(contentsOf: row.validate())
+            if (quietly) {
+                res.append(contentsOf: row.validate(quietly: quietly))
+            } else {
+                res.append(contentsOf: row.validate())
+            }
             return res
         }
     }

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -399,11 +399,7 @@ extension Form {
         
         return rowsWithDisabledFilter.reduce([ValidationError]()) { res, row in
             var res = res
-            if (quietly) {
-                res.append(contentsOf: row.validate(quietly: quietly))
-            } else {
-                res.append(contentsOf: row.validate())
-            }
+            res.append(contentsOf: row.validate(quietly: quietly))
             return res
         }
     }

--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -85,13 +85,17 @@ open class RowOf<T>: BaseRow where T: Equatable {
     public internal(set) var rules: [ValidationRuleHelper<T>] = []
 
     @discardableResult
-    public override func validate() -> [ValidationError] {
+    public override func validate(quietly: Bool = false) -> [ValidationError] {
+        var vErrors = [ValidationError]()
         #if swift(>=4.1)
-        validationErrors = rules.compactMap { $0.validateFn(value) }
+        vErrors = rules.compactMap { $0.validateFn(value) }
         #else
-        validationErrors = rules.flatMap { $0.validateFn(value) }
+        vErrors = rules.flatMap { $0.validateFn(value) }
         #endif
-        return validationErrors
+        if (!quietly) {
+            validationErrors = vErrors
+        }
+        return vErrors
     }
     
     /// Resets the value of the row. Setting it's value to it's reset value.

--- a/Source/Core/RowType.swift
+++ b/Source/Core/RowType.swift
@@ -72,7 +72,7 @@ public protocol BaseRowType: Taggable {
     /**
      Typically we don't need to explicitly call this method since it is called by Eureka framework. It will validates the row if you invoke it.
      */
-    func validate() -> [ValidationError]
+    func validate(quietly: Bool) -> [ValidationError]
 }
 
 public protocol TypedRowType: BaseRowType {


### PR DESCRIPTION
I did not read any contributing documents of any kind. I needed to solve a problem and solved it. Just decided to share the solution. I am open to providing tests/documentation, but wanted feedback first to see if this is an appropriate solution.

On #870 several suggestions were made to make it easier to tie a save button to validation results. I tried to solve this problem by extending Form and Row and BaseRow... etc. In the end I found it was too much private variables to do that way. So I went and added a "quietly" parameter to Form.validate and Row.validate.

Since this parameter defaults to false, I can't see how it would have any effect on normal usage.

I then use Form.validate(quietly: True) in onRowValidationChanged and in onChanged with a closure to update the ui save button.

This has the effect of frequently re-validating the entire form. I couldn't see a way around that in the current architecture. Since saving ValidationErrors is what triggers various callbacks, I simply prevented that from happening. Ideally, one would be able to simply read in all the current validation errors after doing a form validation on init. Once they change to 0, then the form is valid. And validation wouldn't have to be constantly re-done for the entire form.

This allowed "empty" forms and rows not to show validation errors until interacted with but still let the Save button state be 100% current.

I am opening two other issues I have discovered while writing this. A redux of Number/Decimal formatter and SegmentedRow not calling onRowValidationChanged.