### PR TITLE
switched to displayValue instead of row.displayValueFor

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -232,7 +232,7 @@ open class _FieldCell<T> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: 
             titleLabel?.textColor = row.isDisabled ? .gray : .black
         }
         textField.delegate = self
-        textField.text = row.displayValueFor?(row.value)
+        textField.text = displayValue(useFormatter: true)
         textField.isEnabled = !row.isDisabled
         textField.textColor = row.isDisabled ? .gray : .black
         textField.font = .preferredFont(forTextStyle: .body)


### PR DESCRIPTION
It is not clear to me why this change works. But it does as long as there is a formatter present. If there is no formatter it displays the raw value returned.

Since this is on cellUpdate, I would assume we would always want to use the formatter. However, it may be more sensible to separate functions for validation cell updating and content updating (the content often only being set once for a UI element controlled by the user). There really shouldn't be a reason to interfere with the textField.text value that isn't in response to the user. It seems like sole ownership of that should belong to textField delegates and UI interactions.

One possible exception scenario I can think of is content updates to the field coming from some background process. I can't imagine this leading to a good UX experience, so probably not a good idea.

Anyway, this seems to solve this problem. I haven't tried all the varieties of formatting styles to see if it works with them yet.