### PR TITLE
Fix keyboard scrolling caret invisible

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1012,7 +1012,10 @@ extension FormViewController {
         let endFrame = keyBoardInfo[UIResponder.keyboardFrameEndUserInfoKey] as! NSValue
 
         let keyBoardFrame = table.window!.convert(endFrame.cgRectValue, to: table.superview)
-        let newBottomInset = table.frame.origin.y + table.frame.size.height - keyBoardFrame.origin.y + rowKeyboardSpacing
+        var newBottomInset = table.frame.origin.y + table.frame.size.height - keyBoardFrame.origin.y + rowKeyboardSpacing
+        if let tabBar = tabBarController?.tabBar, tabBar.isTranslucent {
+            newBottomInset -= tabBar.frame.size.height
+        }
         var tableInsets = table.contentInset
         var scrollIndicatorInsets = table.scrollIndicatorInsets
         oldBottomInset = oldBottomInset ?? tableInsets.bottom


### PR DESCRIPTION
Fixed bug where the table view would scroll too far up when the keyboard shows, when presented in a tab bar controller with a translucent tab bar. 
If the tab bar is translucent the form's table view extends behind the tab bar to the bottom screen edge and since the content inset accounts for the tab bar, the `newBottomInset` becomes too large.

The bug becomes really annoying with e.g. a tall TextAreaRow's on an iPad in landscape, as you can't see what you type:
![invisible-caret](https://user-images.githubusercontent.com/3512794/57681541-30c16800-7630-11e9-9ff1-9be0fe8f884c.gif)
