### PR TITLE
RuleMinLenght (and others) should pass for nil and empty strings.

### DIFF
--- a/Source/Validations/RuleLength.swift
+++ b/Source/Validations/RuleLength.swift
@@ -39,7 +39,7 @@ public struct RuleMinLength: RuleType {
     }
 
     public func isValid(value: String?) -> ValidationError? {
-        guard let value = value else { return nil }
+        guard let value = value, !value.isEmpty else { return nil }
         return value.count < Int(min) ? validationError : nil
     }
 }
@@ -59,7 +59,7 @@ public struct RuleMaxLength: RuleType {
     }
 
     public func isValid(value: String?) -> ValidationError? {
-        guard let value = value else { return nil }
+        guard let value = value, !value.isEmpty else { return nil }
         return value.count > Int(max) ? validationError : nil
     }
 }
@@ -78,7 +78,7 @@ public struct RuleExactLength: RuleType {
     }
     
     public func isValid(value: String?) -> ValidationError? {
-        guard let value = value else { return nil }
+        guard let value = value, !value.isEmpty else { return nil }
         return value.count != Int(length) ? validationError : nil
     }
 }


### PR DESCRIPTION
RuleRequired manages those cases.

Fixes #1848

