### PR TITLE
Adding support for SPM

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		51729E661B9A5FA5004A00EB /* Eureka.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Eureka.h; path = Source/Eureka.h; sourceTree = SOURCE_ROOT; };
 		798C5AD91EF1E35600A21F52 /* SwipeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActions.swift; sourceTree = "<group>"; };
 		8690E4BD1CFDE062004CDB1C /* Eureka.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Eureka.bundle; sourceTree = "<group>"; };
+		8930319E22C3DBCE00BB3D21 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		8FCCF8EE20A24085004793A0 /* DoublePickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoublePickerRow.swift; sourceTree = "<group>"; };
 		8FCCF8F020A32613004793A0 /* TriplePickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriplePickerRow.swift; sourceTree = "<group>"; };
 		8FCCF92220A473E7004793A0 /* DoublePickerInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoublePickerInputRow.swift; sourceTree = "<group>"; };
@@ -332,6 +333,7 @@
 		51729DE11B9A4F5E004A00EB = {
 			isa = PBXGroup;
 			children = (
+				8930319E22C3DBCE00BB3D21 /* Package.swift */,
 				51729DED1B9A4F5E004A00EB /* Source */,
 				51729DF91B9A4F5E004A00EB /* Tests */,
 				51729DEC1B9A4F5E004A00EB /* Products */,

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Eureka",
+    platforms: [.iOS("9.0")],
+    products: [
+        .library(name: "Eureka", targets: ["Eureka"])
+    ],
+    targets: [
+        .target(
+            name: "Eureka",
+            path: "Source"
+        ),
+        .testTarget(
+            name: "EurekaTests",
+            dependencies: ["Eureka"],
+            path: "Tests"
+        )
+    ]
+)


### PR DESCRIPTION
Adds support for SPM, based on #1871 

CAUTION: the `Package.swift` file does not include a reference to `Eureka.bundle` because does not (yet) support ressources and assets (should change soon though AFAIK).