### PR TITLE
Updated documentation to refer to the correct property

### DIFF
--- a/Source/Rows/Common/FieldRow.swift
+++ b/Source/Rows/Common/FieldRow.swift
@@ -87,7 +87,7 @@ open class FieldRow<Cell: CellType>: FormatteableRow<Cell>, FieldRowConformance,
     open var keyboardReturnType: KeyboardReturnTypeConfiguration?
 
     /// The percentage of the cell that should be occupied by the textField
-	@available (*, deprecated, message: "Use titleLabelPercentage instead")
+	@available (*, deprecated, message: "Use titlePercentage instead")
 	open var textFieldPercentage : CGFloat? {
 		get {
 			return titlePercentage.map { 1 - $0 }


### PR DESCRIPTION
I ran across this deprecation warning in a project and spent a good 10 minutes trying to find the titleLabelPercentage property till I realized it probably just means titlePercentage.

I assume this is the real meaning of the deprecation warning.