### PR TITLE
Fixes documentation warning

### DIFF
--- a/Source/Rows/Common/DecimalFormatter.swift
+++ b/Source/Rows/Common/DecimalFormatter.swift
@@ -43,8 +43,8 @@ open class DecimalFormatter: NumberFormatter, FormatterProtocol {
 
     /// Creates an NSNumber from the given String
     /// - Parameter obj: Pointer to NSNumber object to assign
-    /// - Parameter for: String with number assumed to have the configured min. fraction digits.
-    /// - Parameter range: Unused range parameter 
+    /// - Parameter string: String with number assumed to have the configured min. fraction digits.
+    /// - Parameter rangep: Unused range parameter
     override open func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, range rangep: UnsafeMutablePointer<NSRange>?) throws {
         guard obj != nil else { return  }
         let str = string.components(separatedBy: CharacterSet.decimalDigits.inverted).joined(separator: "")


### PR DESCRIPTION
Building on Xcode 11 produces a pair of documentation warnings related to the documented parameter names on `DecimalFormatter.getObjectValue()`. This commit recreates the doc comment with Xcode's generated parameter names.

-----

The warning:

```
Documentation Issue Group
/Users/aaron/repos/obakit/Carthage/Build/iOS/Eureka.framework/Headers/Eureka-Swift.h:229:12: Parameter 'for' not found in the function declaration
/Users/aaron/repos/obakit/Carthage/Build/iOS/Eureka.framework/Headers/Eureka-Swift.h:231:12: Parameter 'range' not found in the function declaration
```

<img width="667" alt="Screen Shot 2019-09-13 at 11 04 54 PM" src="https://user-images.githubusercontent.com/2254/64904212-83ad3980-d67b-11e9-9bf3-f6018c044e62.png">
