### PR TITLE
Allows a section's header and footer to be `nil`

### DIFF
--- a/Example/Example/Controllers/MultivaluedExamples.swift
+++ b/Example/Example/Controllers/MultivaluedExamples.swift
@@ -83,8 +83,7 @@ class MultivaluedController: FormViewController {
             +++
 
             MultivaluedSection(multivaluedOptions: [.Insert, .Delete, .Reorder],
-                               header: "Multivalued Push Selector example",
-                               footer: "") {
+                               header: "Multivalued Push Selector example") {
                                 $0.tag = "push"
                                 $0.multivaluedRowToInsertAt = { index in
                                     return PushRow<String>{
@@ -117,8 +116,7 @@ class MultivaluedOnlyReorderController: FormViewController {
         form +++
 
             MultivaluedSection(multivaluedOptions: .Reorder,
-                               header: "Reordering Selectors",
-                               footer: "") {
+                               header: "Reordering Selectors") {
                                 $0 <<< PushRow<String> {
                                     $0.title = "Tap to select ;).."
                                     $0.options = ["Option 1", "Option 2", "Option 3"]
@@ -141,8 +139,7 @@ class MultivaluedOnlyReorderController: FormViewController {
             +++
             // Multivalued Section with inline rows - section set up to support only reordering
             MultivaluedSection(multivaluedOptions: .Reorder,
-                               header: "Reordering Inline Rows",
-                               footer: "") { section in
+                               header: "Reordering Inline Rows") { section in
                                 list.enumerated().forEach({ offset, string in
                                     let dateInlineRow = DateInlineRow(){
                                         $0.value = Date(timeInterval: Double(-secondsPerDay) * Double(offset), since: Date())
@@ -155,8 +152,7 @@ class MultivaluedOnlyReorderController: FormViewController {
             +++
 
             MultivaluedSection(multivaluedOptions: .Reorder,
-                               header: "Reordering Field Rows",
-                               footer: "")
+                               header: "Reordering Field Rows")
             <<< NameRow {
                 $0.value = "Martin"
             }

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -186,19 +186,27 @@ open class Section {
         initializer(self)
     }
 
-    public init(_ header: String, _ initializer: @escaping (Section) -> Void = { _ in }) {
-        self.header = HeaderFooterView(stringLiteral: header)
+    public init(_ header: String?, _ initializer: @escaping (Section) -> Void = { _ in }) {
+        if let header = header {
+            self.header = HeaderFooterView(stringLiteral: header)
+        }
         initializer(self)
     }
 
-    public init(header: String, footer: String, _ initializer: (Section) -> Void = { _ in }) {
-        self.header = HeaderFooterView(stringLiteral: header)
-        self.footer = HeaderFooterView(stringLiteral: footer)
+    public init(header: String?, footer: String?, _ initializer: (Section) -> Void = { _ in }) {
+        if let header = header {
+            self.header = HeaderFooterView(stringLiteral: header)
+        }
+        if let footer = footer {
+            self.footer = HeaderFooterView(stringLiteral: footer)
+        }
         initializer(self)
     }
 
-    public init(footer: String, _ initializer: (Section) -> Void = { _ in }) {
-        self.footer = HeaderFooterView(stringLiteral: footer)
+    public init(footer: String?, _ initializer: (Section) -> Void = { _ in }) {
+        if let footer = footer {
+            self.footer = HeaderFooterView(stringLiteral: footer)
+        }
         initializer(self)
     }
 
@@ -493,8 +501,8 @@ open class MultivaluedSection: Section {
     public var multivaluedRowToInsertAt: ((Int) -> BaseRow)?
 
     public required init(multivaluedOptions: MultivaluedOptions = MultivaluedOptions.Insert.union(.Delete),
-                header: String = "",
-                footer: String = "",
+                header: String? = nil,
+                footer: String? = nil,
                 _ initializer: (MultivaluedSection) -> Void = { _ in }) {
         self.multivaluedOptions = multivaluedOptions
         super.init(header: header, footer: footer, {section in initializer(section as! MultivaluedSection) })

--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -127,13 +127,13 @@ open class SelectableSection<Row>: Section, SelectableSectionType where Row: Sel
         initializer(self)
     }
 
-    public init(_ header: String, selectionType: SelectionType, _ initializer: @escaping (SelectableSection<Row>) -> Void = { _ in }) {
+    public init(_ header: String?, selectionType: SelectionType, _ initializer: @escaping (SelectableSection<Row>) -> Void = { _ in }) {
         self.selectionType = selectionType
         super.init(header, { _ in })
         initializer(self)
     }
 
-    public init(header: String, footer: String, selectionType: SelectionType, _ initializer: @escaping (SelectableSection<Row>) -> Void = { _ in }) {
+    public init(header: String?, footer: String?, selectionType: SelectionType, _ initializer: @escaping (SelectableSection<Row>) -> Void = { _ in }) {
         self.selectionType = selectionType
         super.init(header: header, footer: footer, { _ in })
         initializer(self)

--- a/Tests/MultivaluedSectionTests.swift
+++ b/Tests/MultivaluedSectionTests.swift
@@ -44,6 +44,18 @@ class MultivaluedSectionTests: XCTestCase {
         super.tearDown()
     }
 
+    func testHeaders() {
+        let headerSection = MultivaluedSection(multivaluedOptions: .Insert, header: "Header Text", footer: nil) { _ in }
+        XCTAssertEqual(headerSection.header!.title, "Header Text")
+        XCTAssertNil(headerSection.footer)
+    }
+
+    func testFooters() {
+        let footerSection = MultivaluedSection(multivaluedOptions: .Insert, header: nil, footer: "Footer Text") { _ in }
+        XCTAssertEqual(footerSection.footer!.title, "Footer Text")
+        XCTAssertNil(footerSection.header)
+    }
+
     func testAddButton() {
         let section = MultivaluedSection(multivaluedOptions: .Insert, header: "", footer: "") { _ in
             // just an empty closure


### PR DESCRIPTION
Under the hood, a `Section`'s header and footer can both be `nil`, but the available initializers do not allow you to specify `nil` values for these unless you use the zero-argument init method.

This change is backwards-compatible, and should not affect any existing code.

