### PR TITLE
fix for iOS 13 that was not removing the row automatically anymore…

### DIFF
--- a/Source/Core/SwipeActions.swift
+++ b/Source/Core/SwipeActions.swift
@@ -36,7 +36,14 @@ public class SwipeAction: ContextualAction {
         if #available(iOS 11, *){
             action = UIContextualAction(style: style.contextualStyle as! UIContextualAction.Style, title: title){ [weak self] action, view, completion -> Void in
                 guard let strongSelf = self else{ return }
-                strongSelf.handler(strongSelf, forRow, completion)
+                strongSelf.handler(strongSelf, forRow) { shouldComplete in
+                    if #available(iOS 13, *) { // starting in iOS 13, completion handler is not removing the row automatically, so we need to remove it ourselves
+                        if shouldComplete && action.style == .destructive {
+                            forRow.section?.remove(at: forRow.indexPath!.row)
+                        }
+                    }
+                    completion(shouldComplete)
+                }
             }
         } else {
             action = UITableViewRowAction(style: style.contextualStyle as! UITableViewRowAction.Style,title: title){ [weak self] (action, indexPath) -> Void in


### PR DESCRIPTION
…even after calling the completion handler in a destructive swipe action.

This bug is easily reproducible using the Eureka Example Project: Running the app, just choose the "Swipe Actions" row and try to remove a row. If you are running iOS 13, the row will not be removed while it does get removed if the app is running a former iOS version.

This PR fixes the [Issue 1923](https://github.com/xmartlabs/Eureka/issues/1923)

