### PR TITLE
Fix scrollToRow to respect safe area insets

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1025,12 +1025,11 @@ extension FormViewController {
             table.contentInset = tableInsets
             table.scrollIndicatorInsets = scrollIndicatorInsets
             if let selectedRow = table.indexPath(for: cell) {
-                if ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 11 {
-                    let rect = table.rectForRow(at: selectedRow)
-                    table.scrollRectToVisible(rect, animated: animateScroll)
-                } else {
-                    table.scrollToRow(at: selectedRow, at: .none, animated: animateScroll)
+                var rect = table.rectForRow(at: selectedRow)
+                if #available(iOSApplicationExtension 11.0, *) {
+                    rect.origin.y -= table.safeAreaInsets.top
                 }
+                table.scrollRectToVisible(rect, animated: animateScroll)
             }
             UIView.commitAnimations()
         }


### PR DESCRIPTION
There is a bug in iOS that causes `UITableView.scrollToRow` to not respect safe area insets. Therefore it does scroll to the wrong position.

A demo and description of the issue can be found here: https://github.com/xmartlabs/Eureka/issues/1952

This PR fixes the issue by using `scrollRectToVisible` instead and adding the safeAreaInset manually.