### PR TITLE
Fix table view contentInset adjustment with safe area when keyboard shows

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1012,7 +1012,10 @@ extension FormViewController {
         let endFrame = keyBoardInfo[UIResponder.keyboardFrameEndUserInfoKey] as! NSValue
 
         let keyBoardFrame = table.window!.convert(endFrame.cgRectValue, to: table.superview)
-        let newBottomInset = table.frame.origin.y + table.frame.size.height - keyBoardFrame.origin.y + rowKeyboardSpacing
+        var newBottomInset = table.frame.origin.y + table.frame.size.height - keyBoardFrame.origin.y + rowKeyboardSpacing
+        if #available(iOSApplicationExtension 11.0, *) {
+            newBottomInset = newBottomInset - tableView.safeAreaInsets.bottom
+        }
         var tableInsets = table.contentInset
         var scrollIndicatorInsets = table.scrollIndicatorInsets
         oldBottomInset = oldBottomInset ?? tableInsets.bottom

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -1013,7 +1013,7 @@ extension FormViewController {
 
         let keyBoardFrame = table.window!.convert(endFrame.cgRectValue, to: table.superview)
         var newBottomInset = table.frame.origin.y + table.frame.size.height - keyBoardFrame.origin.y + rowKeyboardSpacing
-        if #available(iOSApplicationExtension 11.0, *) {
+        if #available(iOS 11.0, *) {
             newBottomInset = newBottomInset - tableView.safeAreaInsets.bottom
         }
         var tableInsets = table.contentInset


### PR DESCRIPTION
UITableView will adjust it's `contentInset` with safe area. The adjusted `contentInset` can be derived from `adjustedContentInset` api. When table view is influenced by safe area, `Eureka 5.1.0` has an issue that `contentInset` is adjusted too much after keyboard shows.

Solve #1959 #1953 