### PR TITLE
Mark tableView editActionsForRowAt as deprecated

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -945,6 +945,7 @@ extension FormViewController : UITableViewDelegate {
 		return form[indexPath].trailingSwipe.contextualConfiguration
 	}
 
+    @available(iOS, deprecated: 13, message: "UITableViewRowAction is deprecated, use leading/trailingSwipe actions instead")
 	open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]?{
         guard let actions = form[indexPath].trailingSwipe.contextualActions as? [UITableViewRowAction], !actions.isEmpty else {
             return nil


### PR DESCRIPTION
The corresponding method is deprecated as of iOS 13 and emits a warning when building on iOS13 and greater projects.

This marks the method as deprecated and directs users to use the leading/trailing based API instead (which has already been implemented here).

Comment showing deprecation from `UIKit/UITableView.h`

```objc
// This method supersedes -tableView:titleForDeleteConfirmationButtonForRowAtIndexPath: if return value is non-nil
- (nullable NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath API_DEPRECATED_WITH_REPLACEMENT("tableView:trailingSwipeActionsConfigurationForRowAtIndexPath:", ios(8.0, 13.0)) API_UNAVAILABLE(tvos);
```