### PR TITLE
Unowned self reference crashed on iOS 13

### DIFF
--- a/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "51729E191B9A54F1004A00EB"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "51729E191B9A54F1004A00EB"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Core/RowType.swift
+++ b/Source/Core/RowType.swift
@@ -202,7 +202,7 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onChange(_ callback: @escaping (Self) -> Void) -> Self {
-        callbackOnChange = { [unowned self] in callback(self) }
+        callbackOnChange = { [weak self] in callback(self!) }
         return self
     }
 
@@ -213,7 +213,7 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func cellUpdate(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellUpdate = { [unowned self] in  callback(self.cell, self) }
+        callbackCellUpdate = { [weak self] in  callback(self!.cell, self!) }
         return self
     }
 
@@ -224,7 +224,7 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func cellSetup(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellSetup = { [unowned self] (cell: Cell) in  callback(cell, self) }
+        callbackCellSetup = { [weak self] (cell: Cell) in  callback(cell, self!) }
         return self
     }
 
@@ -235,7 +235,7 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onCellSelection(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellOnSelection = { [unowned self] in  callback(self.cell, self) }
+        callbackCellOnSelection = { [weak self] in  callback(self!.cell, self!) }
         return self
     }
 
@@ -246,13 +246,13 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onCellHighlightChanged(_ callback: @escaping (_ cell: Cell, _ row: Self) -> Void) -> Self {
-        callbackOnCellHighlightChanged = { [unowned self] in callback(self.cell, self) }
+        callbackOnCellHighlightChanged = { [weak self] in callback(self!.cell, self!) }
         return self
     }
 
     @discardableResult
     public func onRowValidationChanged(_ callback: @escaping (_ cell: Cell, _ row: Self) -> Void) -> Self {
-        callbackOnRowValidationChanged = { [unowned self] in  callback(self.cell, self) }
+        callbackOnRowValidationChanged = { [weak self] in  callback(self!.cell, self!) }
         return self
     }
 }


### PR DESCRIPTION
This code should be equivalent but somehow using unowned crashes the app in iOS 13.

Also when building for release the compiler crashes with a segmentation fault.

Fixes #1987 
Fixes #1999 
Fixes #1988 