### PR TITLE
Issue #2025 - fixes crash on Push / Multi value rows.

### DIFF
--- a/Source/Core/RowType.swift
+++ b/Source/Core/RowType.swift
@@ -202,7 +202,12 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onChange(_ callback: @escaping (Self) -> Void) -> Self {
-        callbackOnChange = { [weak self] in callback(self!) }
+        callbackOnChange = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            callback(self)
+        }
         return self
     }
 
@@ -213,7 +218,12 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func cellUpdate(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellUpdate = { [weak self] in  callback(self!.cell, self!) }
+        callbackCellUpdate = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            callback(self.cell, self)
+        }
         return self
     }
 
@@ -224,7 +234,12 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func cellSetup(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellSetup = { [weak self] (cell: Cell) in  callback(cell, self!) }
+        callbackCellSetup = { [weak self] (cell: Cell) in
+            guard let self = self else {
+                return
+            }
+            callback(cell, self)
+        }
         return self
     }
 
@@ -235,7 +250,12 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onCellSelection(_ callback: @escaping ((_ cell: Cell, _ row: Self) -> Void)) -> Self {
-        callbackCellOnSelection = { [weak self] in  callback(self!.cell, self!) }
+        callbackCellOnSelection = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            callback(self.cell, self)
+        }
         return self
     }
 
@@ -246,13 +266,23 @@ extension RowType where Self: BaseRow {
      */
     @discardableResult
     public func onCellHighlightChanged(_ callback: @escaping (_ cell: Cell, _ row: Self) -> Void) -> Self {
-        callbackOnCellHighlightChanged = { [weak self] in callback(self!.cell, self!) }
+        callbackOnCellHighlightChanged = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            callback(self.cell, self)
+        }
         return self
     }
 
     @discardableResult
     public func onRowValidationChanged(_ callback: @escaping (_ cell: Cell, _ row: Self) -> Void) -> Self {
-        callbackOnRowValidationChanged = { [weak self] in  callback(self!.cell, self!) }
+        callbackOnRowValidationChanged = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            callback(self.cell, self)
+        }
         return self
     }
 }


### PR DESCRIPTION
### Background
As described in [Issue #2025](https://github.com/xmartlabs/Eureka/issues/2025), the example app (and apps that use the Push or MultiSelection row types) crash when you tap on those row types.

This PR serves to fix this issue by replacing the use of `[unowned self]` with `[weak self]` in the `RowType.swift` file for the callback blocks.  I can't comment on the exact reason this went from "working" to "crashing", but I know that this PR fixes that crash.

### Breaking Changes
I don't know how this worked before, but the Cells do not refresh automatically when you selected updated values in the example app, but if you scroll them out of view and scroll back to them, they do reflect the updated selection.  I don't know if this is how it behaved before or not, so this is potentially a breaking change, though it's also an improvement in that the app doesn't crash.

***Update*** - The "show updated state" after selecting a push or multi selection works without any issue in the app that I'm building, I'm not sure why it doesn't work properly in the example app.

### Metadata
- Issue(s): https://github.com/xmartlabs/Eureka/issues/2025


### Screenshots
Demonstration of the app not crashing after the fix:

![EurekaCrashFix](https://user-images.githubusercontent.com/2284832/80280356-d09cc800-86c0-11ea-8fd1-44a784f7ca0e.gif)

