### PR TITLE
Workaround for crash in Swift 5.3 beta 2/3

### DIFF
--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -62,7 +62,7 @@ public protocol SelectableSectionType: Collection {
     func selectedRows() -> [SelectableRow]
 }
 
-extension SelectableSectionType where Self: Section {
+extension SelectableSectionType where Element == BaseRow, Self: AnyObject {
     /**
      Returns the selected row of this section. Should be used if selectionType is SingleSelection
      */


### PR DESCRIPTION
This PR provides a workaround to the crash affecting Swift 5.3 betas 2 and 3. It replaces a `Self: Section` constraint with two alternate constraints that allow the code to achieve the same result.

Working around bugs in beta compilers isn't always the best approach so I understand if this doesn't get merged. It's mostly an FYI for anyone looking to get around the crash in the meantime.