### PR TITLE
Update SelectorViewController.swift

### DIFF
--- a/Source/Rows/Controllers/SelectorViewController.swift
+++ b/Source/Rows/Controllers/SelectorViewController.swift
@@ -196,7 +196,7 @@ open class _SelectorViewController<Row: SelectableRowType, OptionsRow: OptionsPr
                 self?.row.value = row.value
                 
                 if let form = row.section?.form {
-                    for section in form where section !== row.section {
+                    for section in form where section !== row.section && section is SelectableSection<Row> {
                         let section = section as Any as! SelectableSection<Row>
                         if let selectedRow = section.selectedRow(), selectedRow !== row {
                             selectedRow.value = nil


### PR DESCRIPTION
Make sure sections which are looped is SelectableSection<Row> so force unwrapping does not fail.

I have made a custom SelectorViewController in my project where I added additional section with `SwitchRow` to show hide additional options but it crashes because it tries to force unwrap my section `as! SelectableSection<Row>` but is not.
