### PR TITLE
Fix DateInlineRow, TimeInlineRow and DateTimeInlineRow style/rend…

### DIFF
--- a/Source/Rows/DateInlineRow.swift
+++ b/Source/Rows/DateInlineRow.swift
@@ -118,7 +118,7 @@ open class _CountDownInlineRow: _DateInlineFieldRow {
 public final class DateInlineRow_<T>: _DateInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, inlineRow in
+        onExpandInlineRow { cell, row, _ in
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -141,7 +141,7 @@ public typealias DateInlineRow = DateInlineRow_<Date>
 public final class DateTimeInlineRow_<T>: _DateTimeInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, inlineRow in
+        onExpandInlineRow { cell, row, _ in
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -164,7 +164,7 @@ public typealias DateTimeInlineRow = DateTimeInlineRow_<Date>
 public final class TimeInlineRow_<T>: _TimeInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, inlineRow in
+        onExpandInlineRow { cell, row, _ in
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color

--- a/Source/Rows/DateInlineRow.swift
+++ b/Source/Rows/DateInlineRow.swift
@@ -32,6 +32,16 @@ extension DatePickerRowProtocol {
         inlineRow.maximumDate = maximumDate
         inlineRow.minuteInterval = minuteInterval
     }
+    
+    func configurePickerStyle(_ inlineRow: _DatePickerRow, _ mode: UIDatePicker.Mode = .dateAndTime) {
+        inlineRow.cell.datePicker.datePickerMode = mode
+        if #available(iOS 14.0, *) {
+            inlineRow.cell.datePicker.preferredDatePickerStyle = .inline
+        }
+        else if #available(iOS 13.4, *) {
+            inlineRow.cell.datePicker.preferredDatePickerStyle = .wheels
+        }
+    }
 
 }
 
@@ -47,6 +57,7 @@ open class _DateInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: DatePickerRow) {
         configureInlineRow(inlineRow)
+        configurePickerStyle(inlineRow, .date)
     }
 }
 
@@ -62,6 +73,7 @@ open class _TimeInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: TimePickerRow) {
         configureInlineRow(inlineRow)
+        configurePickerStyle(inlineRow, .time)
     }
 }
 
@@ -77,6 +89,7 @@ open class _DateTimeInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: DateTimePickerRow) {
         configureInlineRow(inlineRow)
+        configurePickerStyle(inlineRow)
     }
 }
 
@@ -106,15 +119,6 @@ public final class DateInlineRow_<T>: _DateInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
         onExpandInlineRow { cell, row, inlineRow in
-            inlineRow.cellUpdate() { cell, row in
-                cell.datePicker.datePickerMode = .date
-                if #available(iOS 14.0, *) {
-                    cell.datePicker.preferredDatePickerStyle = .inline
-                }
-                else if #available(iOS 13.4, *) {
-                    cell.datePicker.preferredDatePickerStyle = .wheels
-                }
-            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -138,15 +142,6 @@ public final class DateTimeInlineRow_<T>: _DateTimeInlineRow, RowType, InlineRow
     required public init(tag: String?) {
         super.init(tag: tag)
         onExpandInlineRow { cell, row, inlineRow in
-            inlineRow.cellUpdate() { cell, row in
-                cell.datePicker.datePickerMode = .dateAndTime
-                if #available(iOS 14.0, *) {
-                    cell.datePicker.preferredDatePickerStyle = .inline
-                }
-                else if #available(iOS 13.4, *) {
-                    cell.datePicker.preferredDatePickerStyle = .wheels
-                }
-            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -170,15 +165,6 @@ public final class TimeInlineRow_<T>: _TimeInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
         onExpandInlineRow { cell, row, inlineRow in
-            inlineRow.cellUpdate() { cell, row in
-                cell.datePicker.datePickerMode = .time
-                if #available(iOS 14.0, *) {
-                    cell.datePicker.preferredDatePickerStyle = .inline
-                }
-                else if #available(iOS 13.4, *) {
-                    cell.datePicker.preferredDatePickerStyle = .wheels
-                }
-            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color

--- a/Source/Rows/DateInlineRow.swift
+++ b/Source/Rows/DateInlineRow.swift
@@ -33,13 +33,13 @@ extension DatePickerRowProtocol {
         inlineRow.minuteInterval = minuteInterval
     }
     
-    func configurePickerStyle(_ inlineRow: _DatePickerRow, _ mode: UIDatePicker.Mode = .dateAndTime) {
-        inlineRow.cell.datePicker.datePickerMode = mode
+    func configurePickerStyle(_ cell: DatePickerCell, _ mode: UIDatePicker.Mode = .dateAndTime) {
+        cell.datePicker.datePickerMode = mode
         if #available(iOS 14.0, *) {
-            inlineRow.cell.datePicker.preferredDatePickerStyle = .inline
+            cell.datePicker.preferredDatePickerStyle = .inline
         }
         else if #available(iOS 13.4, *) {
-            inlineRow.cell.datePicker.preferredDatePickerStyle = .wheels
+            cell.datePicker.preferredDatePickerStyle = .wheels
         }
     }
 
@@ -57,7 +57,7 @@ open class _DateInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: DatePickerRow) {
         configureInlineRow(inlineRow)
-        configurePickerStyle(inlineRow, .date)
+        configurePickerStyle(inlineRow.cell, .date)
     }
 }
 
@@ -73,7 +73,7 @@ open class _TimeInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: TimePickerRow) {
         configureInlineRow(inlineRow)
-        configurePickerStyle(inlineRow, .time)
+        configurePickerStyle(inlineRow.cell, .time)
     }
 }
 
@@ -89,7 +89,7 @@ open class _DateTimeInlineRow: _DateInlineFieldRow {
 
     open func setupInlineRow(_ inlineRow: DateTimePickerRow) {
         configureInlineRow(inlineRow)
-        configurePickerStyle(inlineRow)
+        configurePickerStyle(inlineRow.cell)
     }
 }
 

--- a/Source/Rows/DateInlineRow.swift
+++ b/Source/Rows/DateInlineRow.swift
@@ -105,7 +105,16 @@ open class _CountDownInlineRow: _DateInlineFieldRow {
 public final class DateInlineRow_<T>: _DateInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, _ in
+        onExpandInlineRow { cell, row, inlineRow in
+            inlineRow.cellUpdate() { cell, row in
+                cell.datePicker.datePickerMode = .date
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .inline
+                }
+                else if #available(iOS 13.4, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -128,7 +137,16 @@ public typealias DateInlineRow = DateInlineRow_<Date>
 public final class DateTimeInlineRow_<T>: _DateTimeInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, _ in
+        onExpandInlineRow { cell, row, inlineRow in
+            inlineRow.cellUpdate() { cell, row in
+                cell.datePicker.datePickerMode = .dateAndTime
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .inline
+                }
+                else if #available(iOS 13.4, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color
@@ -151,7 +169,16 @@ public typealias DateTimeInlineRow = DateTimeInlineRow_<Date>
 public final class TimeInlineRow_<T>: _TimeInlineRow, RowType, InlineRowType {
     required public init(tag: String?) {
         super.init(tag: tag)
-        onExpandInlineRow { cell, row, _ in
+        onExpandInlineRow { cell, row, inlineRow in
+            inlineRow.cellUpdate() { cell, row in
+                cell.datePicker.datePickerMode = .time
+                if #available(iOS 14.0, *) {
+                    cell.datePicker.preferredDatePickerStyle = .inline
+                }
+                else if #available(iOS 13.4, *) {
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+            }
             let color = cell.detailTextLabel?.textColor
             row.onCollapseInlineRow { cell, _, _ in
                 cell.detailTextLabel?.textColor = color


### PR DESCRIPTION
Fix DateInlineRow, TimeInlineRow and DateTimeInlineRow style/rendering issues for iOS14. See screenshots from the Example app for details. The default picker view is .inline to match the iOS native apps. If a user is on iOS 13 or lower, they will still see the default style of wheels

### DateInlineRow (before)
![dateBefore](https://user-images.githubusercontent.com/3966567/91220536-4efa8c80-e6ea-11ea-80d5-ee681c844a0a.png)
### DateInlineRow (after)
![dateAfter](https://user-images.githubusercontent.com/3966567/91220529-4d30c900-e6ea-11ea-9e59-458ce87d01e7.png)

### TimeInlineRow (before)
![timeBefore](https://user-images.githubusercontent.com/3966567/91220544-515ce680-e6ea-11ea-9949-31f8fa31b0b6.png)
### TimeInlineRow (after)
![timeAfter](https://user-images.githubusercontent.com/3966567/91220541-50c45000-e6ea-11ea-9726-abaf6dae84c2.png)



### DateTimeInlineRow (before)
![dateTimeBefore](https://user-images.githubusercontent.com/3966567/91220539-50c45000-e6ea-11ea-813b-ace9678096ff.png)
### DateTimeInlineRow (after)
![dateTimeAfter](https://user-images.githubusercontent.com/3966567/91220538-502bb980-e6ea-11ea-8240-3d221bdc00b0.png)



