### PR TITLE
Make tableViewStyle public

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -432,7 +432,7 @@ open class FormViewController: UIViewController, FormViewControllerProtocol, For
 
     /// Defines the behaviour of the navigation between rows
     public var navigationOptions: RowNavigationOptions?
-    private var tableViewStyle: UITableView.Style = .grouped
+    public var tableViewStyle: UITableView.Style = .grouped
 
     public init(style: UITableView.Style) {
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
This PR makes it possible for subclasses of `FormViewController` to specify a `UITableView.Style` for the form table.

This way, a subclass can specify the style e.g. via the initializer called by UIKit:

```
required init?(coder aDecoder: NSCoder) {
    super.init(coder: aDecoder)
    tableViewStyle = .plain
}
```

or lets you specify the style in `viewDidLoad`:
```
override func viewDidLoad() {
    if #available(iOS 13.0, *) {
        self.tableViewStyle = .insetGrouped
    }
    
    super.viewDidLoad()
}
```

## Motivation 
I needed to be able to set the table view style in `viewDidLoad` to `.insetGrouped` in my project but failed at doing so, because the `tableViewStyle`-property in `FormViewController` is marked as private.

## Changes
This simply marks the property `tableViewStyle` as `public` instead of `private`.