### PR TITLE
Add option for different ScrollPosition behavior on keyboard appearance

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -421,6 +421,9 @@ open class FormViewController: UIViewController, FormViewControllerProtocol, For
 
     /// Enables animated scrolling on row navigation
     open var animateScroll = false
+    
+    /// The default scroll position on the focussed cell when keyboard appears
+    open var defaultScrollPosition = UITableView.ScrollPosition.none
 
     /// Accessory view that is responsible for the navigation between rows
     private var navigationAccessoryView: (UIView & NavigationAccessory)!
@@ -1039,7 +1042,7 @@ extension FormViewController {
                     let rect = table.rectForRow(at: selectedRow)
                     table.scrollRectToVisible(rect, animated: animateScroll)
                 } else {
-                    table.scrollToRow(at: selectedRow, at: .none, animated: animateScroll)
+                    table.scrollToRow(at: selectedRow, at: defaultScrollPosition, animated: animateScroll)
                 }
             }
             UIView.commitAnimations()


### PR DESCRIPTION
Hello :wave:

**Context**
The default `tableView.scrollTo` with a `ScrollPosition.none` should animate in a way that the cell is fully visible. It works in most cases, but it seems to fail (scrolls out of view bounds) in the case of a cell preceding a very long footer. Most of the blame here is on Apple side, as I'll show below, however this change request could easily allow to bypass the issue.

**Example/Experiment**
In this commit (https://github.com/lcoderre/Eureka/commit/13c5d65c5f5899bd670267b8729aa0613942f46b) I modified the examples to add a very long Lorem Ipsum footer to a section, and also demonstrated using a pure UITableViewController with scrolling on every cell-click.

👀 - You might notice I recorded this on `iPhone 11 pro` simulator, but I also repeated the test on iPhone 8, 6s. Same Same.

👀 - Even a pure UITableViewController scrolls out of view for that last cell. And on the Eureka's Native Event UI, it acts a bit differently, but buggy all the same.  It is worth noting that Eureka's scrolling behavior shown in the following gif isn't exactly the same as we're observing in our app using Eureka. In our case, it's more like Apple's version 🤷‍♂️  To be honest, I haven't dug in detail to find the reason.

See scrolling using `.none`
![eureka-none-out](https://user-images.githubusercontent.com/2278206/97913271-0d0a4a00-1d1c-11eb-8256-c177ae0bc6da.gif)

See now using `.top` (👀 no bug)
![eureka-top-out](https://user-images.githubusercontent.com/2278206/97913856-f284a080-1d1c-11eb-8eaf-09cb6e021ec9.gif)

**Proposed solution**
The proposed solution has the advantage of being "additive" and not "disruptive". I.e. it won't break anyone's code, but will allow some of us to bypass a nasty problem :)

⚠️ I have not considered extending the pattern to other places where there is scrolling, since I did not know if there was a need. Whereas in the context of keyboard showing up, making sure the cell with textfield was shown was my priority.