### PR TITLE
Prefix Eureka to certain class names to avoid clashes with other pods

### DIFF
--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -26,6 +26,7 @@ import Foundation
 import UIKit
 
 /// Base class for the Eureka cells
+@objc(EurekaBaseCell)
 open class BaseCell: UITableViewCell, BaseCellType {
 
     /// Untyped row associated to this cell.

--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -392,6 +392,7 @@ public struct InlineRowHideOptions: OptionSet {
 }
 
 /// View controller that shows a form.
+@objc(EurekaFormViewController)
 open class FormViewController: UIViewController, FormViewControllerProtocol, FormDelegate {
 
     @IBOutlet public var tableView: UITableView!

--- a/Source/Core/NavigationAccessoryView.swift
+++ b/Source/Core/NavigationAccessoryView.swift
@@ -35,6 +35,7 @@ public protocol NavigationAccessory {
 }
 
 /// Class for the navigation accessory view used in FormViewController
+@objc(EurekaNavigationAccessoryView)
 open class NavigationAccessoryView: UIToolbar, NavigationAccessory {
     open var previousButton: UIBarButtonItem!
     open var nextButton: UIBarButtonItem!


### PR DESCRIPTION
Fixes #2109 

Only classes that inherit from AnyObject or any UIKit classes and no generic classes can be namespaced like this