### PR TITLE
Fix H2O Crash

### DIFF
--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -301,8 +301,10 @@ extension Form {
             switch (changeType as! NSNumber).uintValue {
             case NSKeyValueChange.setting.rawValue:
                 if newSections.count == 0 {
+                    _deletedSections.addObjects(from: oldSections)
                     let indexSet = IndexSet(integersIn: 0..<oldSections.count)
                     delegateValue.sectionsHaveBeenRemoved(oldSections, at: indexSet)
+                    _deletedSections.removeAllObjects()
                 } else {
                     let indexSet = change![NSKeyValueChangeKey.indexesKey] as? IndexSet ?? IndexSet(integersIn: 0..<newSections.count)
                     delegateValue.sectionsHaveBeenAdded(newSections, at: indexSet)

--- a/Source/Rows/Common/GenericMultipleSelectorRow.swift
+++ b/Source/Rows/Common/GenericMultipleSelectorRow.swift
@@ -77,7 +77,7 @@ open class GenericMultipleSelectorRow<T, Cell: CellType>: Row<Cell>, PresenterRo
      */
     open override func prepare(for segue: UIStoryboardSegue) {
         super.prepare(for: segue)
-        guard let rowVC = segue.destination as Any as? PresentedController else { return }
+        guard let rowVC = segue.destination as? PresentedController else { return }
         rowVC.title = selectorTitle ?? rowVC.title
         rowVC.onDismissCallback = presentationMode?.onDismissCallback ?? rowVC.onDismissCallback
         onPresentCallback?(cell.formViewController()!, rowVC)


### PR DESCRIPTION
In Form.swift, in subscript(...) line 171, there's this assertion/crash:
>                 if offsetPosition >= deletedSections.count {
>                     assertionFailure("Form section index of out bounds")
>                 }

This fix makes sure save off the to-be-deleted sections so that the above code doesn't assert.

To reproduce crash:
1. Start H2O
2. Tap on locked loan.
3. Tap Product -> Change Lock
4. Tap on MI Details (across the top)
5. Tap on UPDATE FROM 1003

Stack trace for future reference:
#0	0x000000010aeb1b00 in Form.subscript.getter at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Form.swift:171
#1	0x000000010ae5e207 in FormViewController.tableView(_:heightForHeaderInSection:) at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Core.swift:815
#2	0x000000010ae5e54c in @objc FormViewController.tableView(_:heightForHeaderInSection:) ()
#3	0x00007fff495934e6 in -[UITableView _classicHeightForHeaderInSection:] ()
#4	0x00007fff49598494 in -[UITableView _heightForHeaderInSection:] ()
#5	0x00007fff495aace1 in -[UISectionRowData heightForHeaderInSection:canGuess:] ()
#6	0x00007fff495b16e7 in -[UITableViewRowData rectForHeaderInSection:heightCanBeGuessed:] ()
#7	0x00007fff49552956 in -[UITableView _updateVisibleHeadersAndFootersNow:] ()
#8	0x00007fff4955466e in -[UITableView _updateVisibleCellsNow:] ()
#9	0x00007fff4954cd9f in -[UITableView _setupCellAnimations] ()
#10	0x00007fff4956a9bd in -[UITableView beginUpdates] ()
#11	0x000000010ae5a8a9 in FormViewController.sectionsHaveBeenRemoved(_:at:) at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Core.swift:705
#12	0x000000010ae5c53e in protocol witness for FormDelegate.sectionsHaveBeenRemoved(_:at:) in conformance FormViewController ()
#13	0x000000010aeb9dc8 in Form.KVOWrapper.observeValue(forKeyPath:of:change:context:) at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Form.swift:306
#14	0x000000010aebb476 in @objc Form.KVOWrapper.observeValue(forKeyPath:of:change:context:) ()
#15	0x00007fff25921257 in NSKeyValueNotifyObserver ()
#16	0x00007fff259247f3 in NSKeyValueDidChange ()
#17	0x00007fff259240f5 in -[NSObject(NSKeyValueObservingPrivate) _changeValueForKeys:count:maybeOldValuesDict:maybeNewValuesDict:usingBlock:] ()
#18	0x00007fff259249f2 in -[NSObject(NSKeyValueObservingPrivate) _changeValueForKey:key:key:usingBlock:] ()
#19	0x00007fff2591ea98 in _NSSetObjectValueAndNotify ()
#20	0x000000010aeb8fb7 in Form.KVOWrapper.removeAllSections() at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Form.swift:292
#21	0x000000010aeb774e in Form.removeAll(keepingCapacity:) at /Users/henning/projects/Caliber/CaliberCrash/Pods/Eureka/Source/Core/Form.swift:247
#22	0x000000010819f53f in FormPagePresenter.populateForm() at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/UI/LoanAdvisor/FormPagePresenter.swift:49
#23	0x00000001073aec6b in LoanSummaryWireframe.refreshMIDetails() at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/UI/LoanSummary/LoanSummaryWireframe.swift:759
#24	0x00000001073aeac9 in protocol witness for LoanPagesWireframeProtocol.refreshMIDetails() in conformance LoanSummaryWireframe ()
#25	0x00000001075f34c8 in LoanInformationPagePresenter.updateCalculatedFields(with:) at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/UI/LoanAdvisor/LoanInformationPage/LoanInformationPagePresenter.swift:585
#26	0x00000001075fb4ba in protocol witness for LoanCalculationsPresenter.updateCalculatedFields(with:) in conformance LoanInformationPagePresenter ()
#27	0x00000001073ab802 in LoanSummaryWireframe.updateAfterLoanCalculations(with:) at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/UI/LoanSummary/LoanSummaryWireframe.swift:628
#28	0x00000001073aea9e in protocol witness for LoanSummaryWireframeProtocol.updateAfterLoanCalculations(with:) in conformance LoanSummaryWireframe ()
#29	0x0000000107b2bb2b in closure #2 in LoanSummaryPresenter.mapMiModalResponse(miModal:) at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/UI/LoanSummary/LoanSummaryPresenter.swift:315
#30	0x00000001075f14f6 in thunk for @escaping @callee_guaranteed (@guaranteed LoanCalculationsResult) -> (@error @owned Error) ()
#31	0x0000000107b2bbf4 in partial apply for thunk for @escaping @callee_guaranteed (@guaranteed LoanCalculationsResult) -> (@error @owned Error) ()
#32	0x000000010be2aba1 in closure #1 in closure #1 in Thenable.done(on:flags:_:) at /Users/henning/projects/Caliber/CaliberCrash/Pods/PromiseKit/Sources/Thenable.swift:151
#33	0x000000010bdf5070 in thunk for @escaping @callee_guaranteed () -> () ()
#34	0x000000010cd7ef11 in _dispatch_call_block_and_release ()
#35	0x000000010cd7fe8e in _dispatch_client_callout ()
#36	0x000000010cd8dd97 in _dispatch_main_queue_callback_4CF ()
#37	0x00007fff23da1869 in __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ ()
#38	0x00007fff23d9c3b9 in __CFRunLoopRun ()
#39	0x00007fff23d9b8a4 in CFRunLoopRunSpecific ()
#40	0x00007fff38c05bbe in GSEventRunModal ()
#41	0x00007fff49372964 in UIApplicationMain ()
#42	0x00000001080e2eff in main at /Users/henning/projects/Caliber/CaliberCrash/H2O/_iOS/H2O/main.swift:11
 