### PR TITLE
support M1 Mac arm64 iPhone Simulator and xcframeworks for carthage

### DIFF
--- a/Eureka.xcodeproj/project.pbxproj
+++ b/Eureka.xcodeproj/project.pbxproj
@@ -726,7 +726,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -751,7 +750,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Removing `arm64` exclude arch build settings workaround for carthage by https://github.com/xmartlabs/Eureka/pull/2104 to support
- M1 mac
- recently released carthage v0.37 xcframeworks for M1 mac

users that not using xcframeworks can still workaround for carthage by https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md