### PR TITLE
Fix removeAll method in sections

### DIFF
--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -269,10 +269,11 @@ extension Form : RangeReplaceableCollection {
     }
 
     public func removeAll(where shouldBeRemoved: (Section) throws -> Bool) rethrows {
-        let indices = try kvoWrapper._allSections.enumerated().filter { (element) -> Bool in
-            return try shouldBeRemoved(element.element)
-        }.map { $0.offset }
-        var removedSections: [Section] = []
+        let indices = try kvoWrapper._allSections.enumerated()
+            .filter { try shouldBeRemoved($0.element)}
+            .map { $0.offset }
+
+        var removedSections = [Section]()
         for index in indices.reversed() {
             removedSections.append(kvoWrapper._allSections.remove(at: index))
         }

--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -266,7 +266,19 @@ extension Form : RangeReplaceableCollection {
         for section in sections {
             section.willBeRemovedFromForm()
         }
+    }
 
+    public func removeAll(where shouldBeRemoved: (Section) throws -> Bool) rethrows {
+        let indices = try kvoWrapper._allSections.enumerated().filter { (element) -> Bool in
+            return try shouldBeRemoved(element.element)
+        }.map { $0.offset }
+        var removedSections: [Section] = []
+        for index in indices.reversed() {
+            removedSections.append(kvoWrapper._allSections.remove(at: index))
+        }
+        kvoWrapper.sections.removeObjects(in: removedSections)
+
+        removedSections.forEach { $0.willBeRemovedFromForm() }
     }
 
     private func indexForInsertion(at index: Int) -> Int {

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -334,9 +334,7 @@ extension Section: RangeReplaceableCollection {
         }
         kvoWrapper.rows.removeObjects(in: removedRows)
 
-        for row in removedRows {
-            row.willBeRemovedFromSection()
-        }
+        removedRows.forEach { $0.willBeRemovedFromSection() }
     }
 
     @discardableResult

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -324,6 +324,21 @@ extension Section: RangeReplaceableCollection {
         }
     }
 
+    public func removeAll(where shouldBeRemoved: (BaseRow) throws -> Bool) rethrows {
+        let indices = try kvoWrapper._allRows.enumerated().filter { (element) -> Bool in
+            return try shouldBeRemoved(element.element)
+        }.map { $0.offset }
+        var removedRows: [BaseRow] = []
+        for index in indices.reversed() {
+            removedRows.append(kvoWrapper._allRows.remove(at: index))
+        }
+        kvoWrapper.rows.removeObjects(in: removedRows)
+
+        for row in removedRows {
+            row.willBeRemovedFromSection()
+        }
+    }
+
     @discardableResult
     public func remove(at position: Int) -> BaseRow {
         let row = kvoWrapper.rows.object(at: position) as! BaseRow

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -325,10 +325,11 @@ extension Section: RangeReplaceableCollection {
     }
 
     public func removeAll(where shouldBeRemoved: (BaseRow) throws -> Bool) rethrows {
-        let indices = try kvoWrapper._allRows.enumerated().filter { (element) -> Bool in
-            return try shouldBeRemoved(element.element)
-        }.map { $0.offset }
-        var removedRows: [BaseRow] = []
+        let indices = try kvoWrapper._allRows.enumerated()
+            .filter { try shouldBeRemoved($0.element)}
+            .map { $0.offset }
+        
+        var removedRows = [BaseRow]()
         for index in indices.reversed() {
             removedRows.append(kvoWrapper._allRows.remove(at: index))
         }

--- a/Tests/SectionsInsertionTests.swift
+++ b/Tests/SectionsInsertionTests.swift
@@ -216,6 +216,17 @@ class SectionInsertionTests: XCTestCase {
         XCTAssertEqual(form.allRows.count, 1)
     }
 
+    func testDeletingSections() {
+        let form = Form()
+        form +++ Section("section_0")
+            +++ Section("section_1") { $0.hidden = true }
+            +++ Section("section_22")
+            +++ Section("section_32")
+
+        form.removeAll(where: { section in section.header?.title?.hasSuffix("2") ?? false })
+        XCTAssertEqual(form.allSections.count, 2)        
+    }
+
     private func hideAndShowSections(form: Form, expectedTitles titles: [String]) {
         // Doesn't matter how rows were added to the form (using append, +++ or subscript index)
         // next must work

--- a/Tests/SectionsInsertionTests.swift
+++ b/Tests/SectionsInsertionTests.swift
@@ -227,6 +227,23 @@ class SectionInsertionTests: XCTestCase {
         XCTAssertEqual(form.allSections.count, 2)        
     }
 
+    func testReplaceAllSection() {
+        let form = Form() +++ Section("section1") {
+            $0.hidden = true
+        }
+            +++ Section("section2")
+            +++ Section("section3")
+
+        form.replaceSubrangeInAllSections(Range<Int>(uncheckedBounds: (lower: 0, upper: 2)), with: [Section("section0") { $0.hidden = true }])
+
+        XCTAssertEqual(form.allSections.count, 2)
+        XCTAssertEqual(form.count, 1)
+        XCTAssertEqual(form[0].header?.title, "section3")
+        XCTAssertEqual(form.allSections[0].header?.title, "section0")
+        XCTAssertEqual(form.allSections[1].header?.title, "section3")
+    }
+
+
     private func hideAndShowSections(form: Form, expectedTitles titles: [String]) {
         // Doesn't matter how rows were added to the form (using append, +++ or subscript index)
         // next must work

--- a/Tests/SectionsInsertionTests.swift
+++ b/Tests/SectionsInsertionTests.swift
@@ -201,6 +201,21 @@ class SectionInsertionTests: XCTestCase {
         XCTAssertEqual(form.allRows[2], bRow)
     }
 
+    func testDeletingRows() {
+        let form = Form()
+        let section = Section("section_01")
+        form.append(section)
+
+        section.append(NameRow(tag: "row_01"))
+        section.append(NameRow(tag: "row_2"))
+        section.append(NameRow("row_03") { $0.hidden = true })
+        section.append(NameRow("row_04") { $0.hidden = true })
+
+        section.removeAll(where: { row in row.tag?.hasPrefix("row_0") ?? false })
+        XCTAssertNotNil(form.rowBy(tag: "row_2"))
+        XCTAssertEqual(form.allRows.count, 1)
+    }
+
     private func hideAndShowSections(form: Form, expectedTitles titles: [String]) {
         // Doesn't matter how rows were added to the form (using append, +++ or subscript index)
         // next must work


### PR DESCRIPTION
Override the `removeAll(where:)` method as it causes Duplicate Tag errors

Fixes #2048 