### PR TITLE
Fixes #2159. Specific special characters are allowed in an email address

### DIFF
--- a/Source/Validations/RuleRegExp.swift
+++ b/Source/Validations/RuleRegExp.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 public enum RegExprPattern: String {
-    case EmailAddress = "^[_A-Za-z0-9-+]+(\\.[_A-Za-z0-9-+]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$"
+    case EmailAddress = "^[_A-Za-z0-9-+!?#$%'`*/=~^{}|]+(\\.[_A-Za-z0-9-+!?#$%'`*/=~^{}|]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$"
     case URL = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+([/?#]\\S*)?"
     case ContainsNumber = ".*\\d.*"
     case ContainsCapital = "^.*?[A-Z].*?$"

--- a/Tests/ValidationsTests.swift
+++ b/Tests/ValidationsTests.swift
@@ -116,10 +116,28 @@ class ValidationsTests: XCTestCase {
         XCTAssertNil(emailRule.isValid(value: nil))
         XCTAssertNil(emailRule.isValid(value: ""))
         XCTAssertNil(emailRule.isValid(value: "a@b.com"))
-
+        XCTAssertNil(emailRule.isValid(value: "a!omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a?omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a#omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a$omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a%omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a'omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a`omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a*omalley@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a/omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a=omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a~omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a^omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a/omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a{omally@b.com"))
+        XCTAssertNil(emailRule.isValid(value: "a}omally@b.com"))
+        
         XCTAssertNotNil(emailRule.isValid(value: "abc"))
         XCTAssertNotNil(emailRule.isValid(value: "abc.com"))
         XCTAssertNotNil(emailRule.isValid(value: "abc@assa"))
+        XCTAssertNotNil(emailRule.isValid(value: "a&b@b.com"))
+        XCTAssertNotNil(emailRule.isValid(value: "a[omalley@b.com"))
+        XCTAssertNotNil(emailRule.isValid(value: "a]omalley@b.com"))
     }
 
     func testMaxLengthRule() {


### PR DESCRIPTION
Fixes #2159 