### PR TITLE
Fix a compiler error in Xcode 13 when building for Catalyst

### DIFF
--- a/Source/Core/Cell.swift
+++ b/Source/Core/Cell.swift
@@ -52,7 +52,7 @@ open class BaseCell: UITableViewCell, BaseCellType {
             if let formVC = responder as? FormViewController {
               return formVC
             }
-            responder = responder?.next
+            responder = (responder as? UIResponder)?.next
         }
         return nil
     }


### PR DESCRIPTION
This occurs in Xcode 13.0 beta 1, but may not occur in later betas (we'll see). If this isn't fixed, it has an error:

```
❌  /Users/runner/work/iOS/iOS/Pods/Eureka/Source/Core/Cell.swift:55:34: ambiguous use of 'next'

            responder = responder?.next
```

Presumably this is an error in the compiler, but nonetheless is fixable by making it less ambiguous.