### PR TITLE
UIDatePicker Locale and TimeZone Options

### DIFF
--- a/Example/Example/Controllers/RowsExample.swift
+++ b/Example/Example/Controllers/RowsExample.swift
@@ -42,6 +42,13 @@ class RowsExampleViewController: FormViewController {
                 $0.title = "DateTimeRow"
                 //Force 24 time input
                 $0.locale = Locale(identifier: "en_GB")
+                $0.timeZone = TimeZone(identifier: "UTC")
+                let formatter = DateFormatter()
+                formatter.timeZone = TimeZone(identifier: "UTC")
+                formatter.locale = Locale(identifier: "en_GB")
+                formatter.timeStyle = .full
+                formatter.dateStyle = .short
+                $0.dateFormatter = formatter
             }
 
             <<< CountDownInlineRow() { $0.value = Date(); $0.title = "CountDownInlineRow" }

--- a/Example/Example/Controllers/RowsExample.swift
+++ b/Example/Example/Controllers/RowsExample.swift
@@ -20,6 +20,7 @@ class RowsExampleViewController: FormViewController {
         LabelRow.defaultCellUpdate = { cell, row in cell.detailTextLabel?.textColor = .systemOrange  }
         CheckRow.defaultCellSetup = { cell, row in cell.tintColor = .systemOrange }
         DateRow.defaultRowInitializer = { row in row.minimumDate = Date() }
+        DateTimeRow.defaultRowInitializer = { row in row.minimumDate = Date() }
 
         form +++
 
@@ -35,6 +36,13 @@ class RowsExampleViewController: FormViewController {
             }
 
             <<< DateRow() { $0.value = Date(); $0.title = "DateRow" }
+            
+            <<< DateTimeRow() {
+                $0.value = Date()
+                $0.title = "DateTimeRow"
+                //Force 24 time input
+                $0.locale = Locale(identifier: "en_GB")
+            }
 
             <<< CountDownInlineRow() { $0.value = Date(); $0.title = "CountDownInlineRow" }
             

--- a/Source/Rows/Common/DateFieldRow.swift
+++ b/Source/Rows/Common/DateFieldRow.swift
@@ -29,6 +29,7 @@ public protocol DatePickerRowProtocol: AnyObject {
     var minimumDate: Date? { get set }
     var maximumDate: Date? { get set }
     var minuteInterval: Int? { get set }
+    var locale:Locale? { get set }
 }
 
 open class DateCell: Cell<Date>, CellType {
@@ -69,6 +70,7 @@ open class DateCell: Cell<Date>, CellType {
         datePicker.setDate(row.value ?? Date(), animated: row is CountDownPickerRow)
         datePicker.minimumDate = (row as? DatePickerRowProtocol)?.minimumDate
         datePicker.maximumDate = (row as? DatePickerRowProtocol)?.maximumDate
+        datePicker.locale = (row as? DatePickerRowProtocol)?.locale
         if let minuteIntervalValue = (row as? DatePickerRowProtocol)?.minuteInterval {
             datePicker.minuteInterval = minuteIntervalValue
         }
@@ -119,6 +121,7 @@ open class DateCell: Cell<Date>, CellType {
 }
 
 open class _DateFieldRow: Row<DateCell>, DatePickerRowProtocol, NoValueDisplayTextConformance {
+    
 
     /// The minimum value for this row's UIDatePicker
     open var minimumDate: Date?
@@ -131,6 +134,9 @@ open class _DateFieldRow: Row<DateCell>, DatePickerRowProtocol, NoValueDisplayTe
 
     /// The formatter for the date picked by the user
     open var dateFormatter: DateFormatter?
+    
+    /// The locale for this row's UIDatePicker
+    open var locale: Locale?
 
     open var noValueDisplayText: String? = nil
 

--- a/Source/Rows/Common/DateFieldRow.swift
+++ b/Source/Rows/Common/DateFieldRow.swift
@@ -29,6 +29,7 @@ public protocol DatePickerRowProtocol: AnyObject {
     var minimumDate: Date? { get set }
     var maximumDate: Date? { get set }
     var minuteInterval: Int? { get set }
+    var timeZone:TimeZone? { get set }
     var locale:Locale? { get set }
 }
 
@@ -70,6 +71,7 @@ open class DateCell: Cell<Date>, CellType {
         datePicker.setDate(row.value ?? Date(), animated: row is CountDownPickerRow)
         datePicker.minimumDate = (row as? DatePickerRowProtocol)?.minimumDate
         datePicker.maximumDate = (row as? DatePickerRowProtocol)?.maximumDate
+        datePicker.timeZone = (row as? DatePickerRowProtocol)?.timeZone
         datePicker.locale = (row as? DatePickerRowProtocol)?.locale
         if let minuteIntervalValue = (row as? DatePickerRowProtocol)?.minuteInterval {
             datePicker.minuteInterval = minuteIntervalValue
@@ -137,7 +139,10 @@ open class _DateFieldRow: Row<DateCell>, DatePickerRowProtocol, NoValueDisplayTe
     
     /// The locale for this row's UIDatePicker
     open var locale: Locale?
-
+    
+    /// The TimeZone  for this row's UIDatePicker
+    open var timeZone: TimeZone?
+    
     open var noValueDisplayText: String? = nil
 
     required public init(tag: String?) {

--- a/Source/Rows/Common/DateInlineFieldRow.swift
+++ b/Source/Rows/Common/DateInlineFieldRow.swift
@@ -69,6 +69,9 @@ open class _DateInlineFieldRow: Row<DateInlineCell>, DatePickerRowProtocol, NoVa
     /// The locale for this row's UIDatePicker
     open var locale: Locale?
     
+    /// The TimeZone  for this row's UIDatePicker
+    open var timeZone: TimeZone?
+    
     open var noValueDisplayText: String?
 
     required public init(tag: String?) {

--- a/Source/Rows/Common/DateInlineFieldRow.swift
+++ b/Source/Rows/Common/DateInlineFieldRow.swift
@@ -66,6 +66,9 @@ open class _DateInlineFieldRow: Row<DateInlineCell>, DatePickerRowProtocol, NoVa
     /// The formatter for the date picked by the user
     open var dateFormatter: DateFormatter?
 
+    /// The locale for this row's UIDatePicker
+    open var locale: Locale?
+    
     open var noValueDisplayText: String?
 
     required public init(tag: String?) {

--- a/Source/Rows/DatePickerRow.swift
+++ b/Source/Rows/DatePickerRow.swift
@@ -120,6 +120,7 @@ open class _DatePickerRow: Row<DatePickerCell>, DatePickerRowProtocol {
     open var minimumDate: Date?
     open var maximumDate: Date?
     open var minuteInterval: Int?
+    open var timeZone: TimeZone?
     open var locale: Locale?
     
     required public init(tag: String?) {

--- a/Source/Rows/DatePickerRow.swift
+++ b/Source/Rows/DatePickerRow.swift
@@ -120,7 +120,8 @@ open class _DatePickerRow: Row<DatePickerCell>, DatePickerRowProtocol {
     open var minimumDate: Date?
     open var maximumDate: Date?
     open var minuteInterval: Int?
-
+    open var locale: Locale?
+    
     required public init(tag: String?) {
         super.init(tag: tag)
         displayValueFor = nil


### PR DESCRIPTION
Added option to set locale to force 12/24 hour time input and option to set timezone of the picker.
This can be used for example to input times using a standard location i.e Zulu/UTC