### PR TITLE
SegmentedCell: cast row to OptionsRow not to the SegmentedRow

### DIFF
--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -115,7 +115,7 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
     }
 
     @objc (valueDidChange) func valueChanged() {
-        row.value = (row as! SegmentedRow<T>).options?[segmentedControl.selectedSegmentIndex]
+        row.value = (row as! OptionsRow<Self>).options?[segmentedControl.selectedSegmentIndex]
     }
 
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -131,7 +131,7 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
     func updateSegmentedControl() {
         segmentedControl.removeAllSegments()
 
-        (row as! SegmentedRow<T>).options?.reversed().forEach {
+        (row as! OptionsRow<Self>).options?.reversed().forEach {
             if let image = $0 as? UIImage {
                 segmentedControl.insertSegment(with: image, at: 0, animated: false)
             } else {
@@ -180,7 +180,7 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
 
     func selectedIndex() -> Int? {
         guard let value = row.value else { return nil }
-        return (row as! SegmentedRow<T>).options?.firstIndex(of: value)
+        return (row as! OptionsRow<Self>).options?.firstIndex(of: value)
     }
 }
 


### PR DESCRIPTION
SegmentedCell can only be used with SegmentedRow. It force-casts the row value to SegmentedRow<T> when it reads an options variable. Actually this var is a part of OptionsProviderRow protocol. 
Changing the casting type to OptionsRow<Self> allows us to keep the same behaviour for existing classes and extends the reuse of  SegmentedCell.
We cannot modify SegmentedRow class, because it is marked as final, but we will be able to use this cell in custom classes:


    // MARK: AdvancedSegmentedRow
    public final class AdvancedSegmentedRow<T: Equatable>: OptionsRow<SegmentedCell<T>>, RowType {
      required public init(tag: String?) {
        super.init(tag: tag)
      }

    public override func updateCell() {
        super.updateCell()
        cell.applyDisabledAppearance()
      }
    } 
