### PR TITLE
Fix internal inconsistency exceptions caused by cell updates

### DIFF
--- a/Source/Core/Row.swift
+++ b/Source/Core/Row.swift
@@ -172,10 +172,13 @@ open class Row<Cell: CellType>: RowOf<Cell.Value>, TypedRowType where Cell: Base
      */
     override open func updateCell() {
         super.updateCell()
-        cell.update()
-        customUpdateCell()
-        RowDefaults.cellUpdate["\(type(of: self))"]?(cell, self)
-        callbackCellUpdate?()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.cell.update()
+            self.customUpdateCell()
+            RowDefaults.cellUpdate["\(type(of: self))"]?(self.cell, self)
+            self.callbackCellUpdate?()
+        }
     }
 
     /**


### PR DESCRIPTION
Regarding the issue #2189 I opened previously, here is a proposed fix.

The current problem seems to be that some updates of the cell from within `.cellUpdate` can cause an internal inconsistency exception:
`'NSInternalInconsistencyException', reason: 'UITableView internal inconsistency: _visibleRows and _visibleCells must be of same length.` This can cause a crash of the app.

The fix proposed here eliminates this exception by moving the cellUpdate call out from the current call stack back into the next main loop run.

Tested with iOS 15.2 and Xcode 13.2.