### PR TITLE
[Bug] Mac Catalyst: set the correct deprecated version

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -955,6 +955,7 @@ extension FormViewController : UITableViewDelegate {
 		return form[indexPath].trailingSwipe.contextualConfiguration
 	}
 
+    @available(macCatalyst, deprecated: 13.1, message: "UITableViewRowAction is deprecated, use leading/trailingSwipe actions instead")
     @available(iOS, deprecated: 13, message: "UITableViewRowAction is deprecated, use leading/trailingSwipe actions instead")
 	open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]?{
         guard let actions = form[indexPath].trailingSwipe.contextualActions as? [UITableViewRowAction], !actions.isEmpty else {


### PR DESCRIPTION
## Description
Fix a bug in mac-catalyst because `tableView(_:editActionsForRowAt:)` has been deprecated in iOS 13, ipadOS 13 and **macCatalyst 13.1.**

If we do not add the correct deprecation version, it will create an inconsistency between MacOSX SDK and the library. UITableView's headers are explicitly marked deprecated at 13.1, and the library will take 13 (from iOS) - making a premature deprecation in catalyst.

**Source**: https://developer.apple.com/documentation/uikit/uitableviewdelegate/1614956-tableview