### PR TITLE
[Bug] Clear Form once view Did Disappear to prevent leak

### DIFF
--- a/Source/Core/Core.swift
+++ b/Source/Core/Core.swift
@@ -528,6 +528,11 @@ open class FormViewController: UIViewController, FormViewControllerProtocol, For
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        form.removeAll()
+    }
+    
     open override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
         let baseRow = sender as? BaseRow


### PR DESCRIPTION
Particular sections are retained by KVO Wrapper. In order to avoid memory leaks they should be removed explicitly before attempting deallocating VC.

