### PR TITLE
fix bug where tapping TextAreaRow always puts the cursor at the end

### DIFF
--- a/Source/Rows/TextAreaRow.swift
+++ b/Source/Rows/TextAreaRow.swift
@@ -73,7 +73,12 @@ open class _TextAreaCell<T> : Cell<T>, UITextViewDelegate, AreaCell where T: Equ
 
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        let textView = UITextView()
+        let textView: UITextView
+        if #available(iOS 16, *) {
+            textView = UITextView(usingTextLayoutManager: false)
+        } else {
+            textView = UITextView()
+        }
         self.textView = textView
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.keyboardType = .default


### PR DESCRIPTION
on iOS 16, when I tap on a TextAreaRow’s content to start editing, the cursor always goes to the end.

I can reproduce this in Eureka’s sample app. here’s a video:

<img src="https://github.com/xmartlabs/Eureka/assets/8378384/8fb016f6-8022-4477-bbd3-c6ae1bd10586" width=400>

[opting out of TextKit 2](https://developer.apple.com/videos/play/wwdc2022-10090/?time=643) inside _TextAreaCell’s UITextView resolves the issue.