### PR TITLE
Add displayValueForFirstRow and displayValueForSecondRow closure in DoublePickerInlineRow

### DIFF
--- a/Source/Rows/PickerInlineRow.swift
+++ b/Source/Rows/PickerInlineRow.swift
@@ -102,6 +102,12 @@ open class _DoublePickerInlineRow<A, B> : Row<PickerInlineCell<Tuple<A, B>>>, No
 
     /// Options for second component given the selected value from the first component. Will be called often so should be O(1)
     public var secondOptions: ((A) -> [B]) = { _ in [] }
+
+    /// Modify the displayed values for the first picker row.
+    public var displayValueForFirstRow: ((A) -> (String)) = { a in return String(describing: a) }
+
+    /// Modify the displayed values for the second picker row.
+    public var displayValueForSecondRow: ((B) -> (String)) = { b in return String(describing: b) }
     
     public var noValueDisplayText: String?
 
@@ -140,6 +146,8 @@ public final class DoublePickerInlineRow<A, B> : _DoublePickerInlineRow<A, B>, R
     public func setupInlineRow(_ inlineRow: InlineRow) {
         inlineRow.firstOptions = firstOptions
         inlineRow.secondOptions = secondOptions
+        inlineRow.displayValueForFirstRow = displayValueForFirstRow
+        inlineRow.displayValueForSecondRow = displayValueForSecondRow
         inlineRow.displayValueFor = self.displayValueFor
         inlineRow.cell.height = { UITableView.automaticDimension }
     }


### PR DESCRIPTION
Currently there's no way to configure the way that an DoublePickerInlineRow displays its values in the picker, which is avaliable in DoublePickerRow and DoublePickerInputRow. This pull request addresses that missing feature.

After:
<img width="283" alt="Screenshot 2023-05-23 at 3 23 49 PM" src="https://github.com/xmartlabs/Eureka/assets/6411753/f6642dd1-50a3-455b-a8e4-56aaff6d060c">
