### PR TITLE
Improve URL pattern matching

### DIFF
--- a/Source/Validations/RuleRegExp.swift
+++ b/Source/Validations/RuleRegExp.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public enum RegExprPattern: String {
     case EmailAddress = "^[_A-Za-z0-9-+!?#$%'`*/=~^{}|]+(\\.[_A-Za-z0-9-+!?#$%'`*/=~^{}|]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$"
-    case URL = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+([/?#]\\S*)?"
+    case URL = "^(?:(?:http|https)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$"
     case ContainsNumber = ".*\\d.*"
     case ContainsCapital = "^.*?[A-Z].*?$"
     case ContainsLowercase = "^.*?[a-z].*?$"

--- a/Tests/ValidationsTests.swift
+++ b/Tests/ValidationsTests.swift
@@ -167,9 +167,14 @@ class ValidationsTests: XCTestCase {
         XCTAssertNil(urlRule.isValid(value: nil))
         XCTAssertNil(urlRule.isValid(value: URL(string: "")))
         XCTAssertNil(urlRule.isValid(value: URL(string: "http://example.com")))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "http://to.co")))
         XCTAssertNil(urlRule.isValid(value: URL(string: "https://example.com/path/to/file.ext?key=value#location")))
-        
+        XCTAssertNil(urlRule.isValid(value: URL(string: "https://example.com:8080/path/to/file.ext?key=value#location")))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "https://localhost")))
+        XCTAssertNil(urlRule.isValid(value: URL(string: "https://localhost:8080")))
+
         XCTAssertNotNil(urlRule.isValid(value: URL(string: "example.com")))
+        XCTAssertNotNil(urlRule.isValid(value: URL(string: "www.example.com")))
         XCTAssertNotNil(urlRule.isValid(value: URL(string: "http://")))
     }
 }


### PR DESCRIPTION
The current URL regex has a number of issues, for example, it doesn't match `http://localhost` or `https://example.com:8080`.

The proposed expression is taken from [here](https://stackoverflow.com/a/22648406)

It passes all the validation tests including the newly added ones.
