### PR TITLE
Trigger dependency chain

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -146,7 +146,19 @@ open class BaseRow: BaseRowType {
         return IndexPath(row: rowIndex, section: sectionIndex)
     }
 
-    var hiddenCache = false
+	var hiddenCache = false {
+        didSet {
+            guard let t = tag,
+                  let form = section?.form else { return }
+
+            if let rowObservers = form.rowObservers[t]?[.hidden] {
+                for rowObserver in rowObservers {
+                    (rowObserver as? Hidable)?.evaluateHidden()
+                }
+            }
+        }
+    }
+	
     var disabledCache = false {
         willSet {
             if newValue && !disabledCache {

--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -146,7 +146,7 @@ open class BaseRow: BaseRowType {
         return IndexPath(row: rowIndex, section: sectionIndex)
     }
 
-	var hiddenCache = false {
+    var hiddenCache = false {
         didSet {
             guard let t = tag,
                   let form = section?.form else { return }


### PR DESCRIPTION
When having complex dependencies with more then 2 rows `evaluateHidden` works for first level only. With that change all fields in the chain are evaluated.