### PR TITLE
Remove by tag

### DIFF
--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -469,6 +469,13 @@ extension Section /* Helpers */ {
         newRow.wasAddedTo(section: self)
     }
 
+    /// Remove all rows where tags are represented as `CaseIterable` enum cases
+    /// - Parameter type: type of the enum with tags
+    func removeAllRowsWithIterableTags<RowTagType: CaseIterable & RawRepresentable>(type: RowTagType.Type) {
+        type.allCases.forEach { item in
+            removeAll(where: { $0.tag == item.rawValue as? String })
+        }
+    }
 }
 
 /**

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -469,11 +469,17 @@ extension Section /* Helpers */ {
         newRow.wasAddedTo(section: self)
     }
 
+    /// Remove a row for tag represented as enum
+    /// - Parameter type: tag represented as enum
+    public func remove<RowTagType: RawRepresentable>(tag: RowTagType) {
+        removeAll(where: { $0.tag == tag.rawValue as? String })
+    }
+
     /// Remove all rows where tags are represented as `CaseIterable` enum cases
     /// - Parameter type: type of the enum with tags
-    func removeAllRowsWithIterableTags<RowTagType: CaseIterable & RawRepresentable>(type: RowTagType.Type) {
+    public func removeAllRowsWithIterableTags<RowTagType: CaseIterable & RawRepresentable>(type: RowTagType.Type) {
         type.allCases.forEach { item in
-            removeAll(where: { $0.tag == item.rawValue as? String })
+            remove(tag: item)
         }
     }
 }

--- a/Tests/HelperMethodTests.swift
+++ b/Tests/HelperMethodTests.swift
@@ -25,6 +25,12 @@
 import XCTest
 @testable import Eureka
 
+private enum RowTag: String {
+    case first
+    case second
+    case third
+}
+
 class HelperMethodTests: BaseEurekaTests {
 
     func testRowByTag() {
@@ -128,4 +134,14 @@ class HelperMethodTests: BaseEurekaTests {
         XCTAssertEqual(allSections.count, 6)
     }
 
+    func testRemoveForTag() {
+        let row = LabelRow(tag: RowTag.first.rawValue)
+        manySectionsForm[0] <<< LabelRow(tag: RowTag.first.rawValue)
+        XCTAssertEqual(manySectionsForm[0].rowBy(tag: RowTag.first.rawValue), row)
+        manySectionsForm[0].remove(tag: RowTag.first)
+    }
+
+    func testRemoveAllRowsWithIterableTags() {
+    
+    }
 }


### PR DESCRIPTION
Hello.
Thank you for Eureka.
Added some convenient methods to handle tags represented as `enum`.