### PR TITLE
Fix removeRowObservers destroying unrelated observer types

### DIFF
--- a/Source/Core/Form.swift
+++ b/Source/Core/Form.swift
@@ -374,7 +374,7 @@ extension Form {
             guard let arr = rowObservers[rowTag]?[type], let index = arr.firstIndex(where: { $0 === taggable }) else { continue }
             rowObservers[rowTag]?[type]?.remove(at: index)
             if rowObservers[rowTag]?[type]?.isEmpty == true {
-                rowObservers[rowTag] = nil
+                rowObservers[rowTag]?[type] = nil
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fix a bug in `Form.removeRowObservers(from:rowTags:type:)` where removing the last observer of a given `ConditionType` for a tag would destroy all observer types for that tag

## Problem

When different rows register observers of different types (`.hidden`, `.disabled`) on the same dependency tag, removing the last `.disabled` observer for that tag destroys the `.hidden` observers of other rows sharing the same tag.

For example, if row A and row B have `.hidden` conditions depending on tag `fieldX`, and row C has a `.disabled` condition also depending on `fieldX`:

1. `rowObservers["fieldX"]` contains both `.hidden: [rowA, rowB]` and `.disabled: [rowC]`
2. When row C's `.disabled` condition is re-set (e.g. via `toggleEdition()`), `removeFromDisabledRowObservers()` empties the `.disabled` array
3. The cleanup does `rowObservers["fieldX"] = nil` — destroying the `.hidden` observers of row A and row B
4. Hidden conditions for row A and row B silently stop re-evaluating

## Fix

In `Form.removeRowObservers(from:rowTags:type:)`, replace `rowObservers[rowTag] = nil` with `rowObservers[rowTag]?[type] = nil` to only clear the emptied type, leaving other observer types intact.